### PR TITLE
FbxLoaderをもとに戻した

### DIFF
--- a/RakiEngine_Library/FbxLoader.h
+++ b/RakiEngine_Library/FbxLoader.h
@@ -68,7 +68,6 @@ private:
 	
 	//テクスチャはテクスチャマネージャーのしごと
 
-
 	FbxManager* fbxmgr = nullptr;
 
 	FbxImporter* fbxImporter = nullptr;

--- a/TD4_Game/Resources/Shaders/FBXVertexShader.hlsl
+++ b/TD4_Game/Resources/Shaders/FBXVertexShader.hlsl
@@ -45,7 +45,7 @@ VSOutput main(VSInput input)
     float4 wn = normalize(mul(wMat, float4(skined.normal, 0)));
 	
 	VSOutput output;//ピクセルシェーダーに渡す値
-    output.worldPos = input.svpos;
+    output.worldPos = mul(wMat, input.svpos);
 	output.svpos = mul(mat, skined.pos);
     output.normal = wn.xyz;
 	output.uv = input.uv;

--- a/TD4_Game/Resources/Shaders/OBJVertexShader.hlsl
+++ b/TD4_Game/Resources/Shaders/OBJVertexShader.hlsl
@@ -3,13 +3,11 @@
 VSOutput main(float4 pos : POSITION, float3 normal : NORMAL, float2 uv : TEXCOORD)
 {
 	VSOutput output;//ピクセルシェーダーに渡す値
-	//頂点座標そのまま
-    output.worldPos = pos;
 	//ビュープロジェクション変換
 	output.svpos = mul(mat, pos);
     output.worldPos = mul(wMat, pos);
 	
-	output.normal = normal;
+    output.normal = normalize(mul(wMat, float4(normal, 0)));
 	output.uv = uv;
 	return output;
 }

--- a/TD4_Game/Resources/hage_1/hage_1.fbx
+++ b/TD4_Game/Resources/hage_1/hage_1.fbx
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:48666d0b516ce71f99e94d2f4d17e8bc94918a950cb3ce653469831b29bb763f
-size 473404
+oid sha256:bc2e073f5dcf2afd06ecc24801826927ba292a74edf166f37247ca7b041d86c1
+size 437628

--- a/TD4_Game/SceneManager.cpp
+++ b/TD4_Game/SceneManager.cpp
@@ -17,6 +17,7 @@ SceneManager::SceneManager() :mNextScene(eScene_None) {
 SceneManager::~SceneManager()
 {
     delete nowScene;
+    nowScene = nullptr;
 }
 
 void SceneManager::Initialize()

--- a/TD4_Game/TD4_Game.exe
+++ b/TD4_Game/TD4_Game.exe
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:85d99e38dedaa3b1c6a82f0c54162078a640f2dab563daf6f323df529a35e89b
-size 15309312

--- a/TD4_Game/imgui.ini
+++ b/TD4_Game/imgui.ini
@@ -4,7 +4,7 @@ Size=400,400
 Collapsed=0
 
 [Window][fbx control]
-Pos=112,46
+Pos=118,46
 Size=150,700
 Collapsed=0
 


### PR DESCRIPTION
# Engine更新

## FBXLoaderをもとに戻した
FBXの描画が崩れる問題があったため、一度フルカワの知識をもとに修正してみたが
ボーンありの描画が治らないどころか悪化したためもとに戻した。
とはいえフルカワのやり方（コントロールポイントを見ない）は法線がずれることがなかったが
現状法線がいかれてライティングが珍妙なことになるので、依然として修正は必要。

## Scenemanagerのリークを更に修正

deleteしたポインタにnullptrを入れた
