### PR TITLE
Engine更新

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,3 +5,4 @@
 *.png filter=lfs diff=lfs merge=lfs -text
 *.jpg filter=lfs diff=lfs merge=lfs -text
 *.exe filter=lfs diff=lfs merge=lfs -text
+*.blend filter=lfs diff=lfs merge=lfs -text

--- a/RakiEngine_Library/DebugCamera.cpp
+++ b/RakiEngine_Library/DebugCamera.cpp
@@ -1,0 +1,1 @@
+#include "DebugCamera.h"

--- a/RakiEngine_Library/DebugCamera.h
+++ b/RakiEngine_Library/DebugCamera.h
@@ -1,0 +1,5 @@
+#pragma once
+class DebugCamera
+{
+};
+

--- a/RakiEngine_Library/DifferrdRenderingMgr.cpp
+++ b/RakiEngine_Library/DifferrdRenderingMgr.cpp
@@ -60,7 +60,7 @@ void DiferredRenderingMgr::Rendering(RTex* gBuffer, RTex* shadowMap)
     //ディファードレンダリング結果出力
     m_cmd->DrawInstanced(6, 1, 0, 0);
 
-    shadowMap->ClearRenderTarget();
+    //shadowMap->ClearRenderTarget();
 
    
 

--- a/RakiEngine_Library/NY_Object3D.cpp
+++ b/RakiEngine_Library/NY_Object3D.cpp
@@ -38,7 +38,7 @@ void Object3d::InitObject3D(ID3D12Device *dev)
 	);
 	constBuffB1.Get()->SetName(L"Object3d_cbuffB1");
 
-	auto skinresdesc = CD3DX12_RESOURCE_DESC::Buffer((sizeof(constBuffSkin) + 0xff) & ~0xff);
+	auto skinresdesc = CD3DX12_RESOURCE_DESC::Buffer((sizeof(ConstBufferDataSkin) + 0xff) & ~0xff);
 
 	result = dev->CreateCommittedResource(
 		&HEAP_PROP,
@@ -48,7 +48,7 @@ void Object3d::InitObject3D(ID3D12Device *dev)
 		nullptr,
 		IID_PPV_ARGS(&constBuffSkin)
 	);
-	constBuffB1.Get()->SetName(L"Object3d_cbuffSkin");
+	constBuffSkin.Get()->SetName(L"Object3d_cbuffSkin");
 
 	//単位行列で初期化
 	ConstBufferDataSkin* constMapSkin = nullptr;
@@ -392,7 +392,7 @@ void Object3d::DrawObject()
 		RAKI_DX12B_CMD->SetGraphicsRootConstantBufferView(0, constBuffB0->GetGPUVirtualAddress());
 		//定数バッファ設定
 		RAKI_DX12B_CMD->SetGraphicsRootConstantBufferView(1, constBuffB1->GetGPUVirtualAddress());
-		RAKI_DX12B_CMD->SetGraphicsRootConstantBufferView(4, constBuffSkin->GetGPUVirtualAddress());
+		RAKI_DX12B_CMD->SetGraphicsRootConstantBufferView(3, constBuffSkin->GetGPUVirtualAddress());
 
 		fbxmodel->Draw();
 	}

--- a/RakiEngine_Library/RakiEngine_Library.vcxproj
+++ b/RakiEngine_Library/RakiEngine_Library.vcxproj
@@ -46,6 +46,7 @@
     <ClCompile Include="Colider.cpp" />
     <ClCompile Include="ColisionManager.cpp" />
     <ClCompile Include="ColliderInfo.cpp" />
+    <ClCompile Include="DebugCamera.cpp" />
     <ClCompile Include="DebugDrawer.cpp" />
     <ClCompile Include="DifferrdRenderingMgr.cpp" />
     <ClCompile Include="DirectionalLight.cpp" />
@@ -102,6 +103,7 @@
     <ClInclude Include="ColisionManager.h" />
     <ClInclude Include="ColliderInfo.h" />
     <ClInclude Include="ColliderShapeType.h" />
+    <ClInclude Include="DebugCamera.h" />
     <ClInclude Include="DebugDrawer.h" />
     <ClInclude Include="DifferrdRenderingMgr.h" />
     <ClInclude Include="DirectionalLight.h" />

--- a/RakiEngine_Library/RakiEngine_Library.vcxproj.filters
+++ b/RakiEngine_Library/RakiEngine_Library.vcxproj.filters
@@ -249,6 +249,9 @@
     <ClCompile Include="NY_Model.cpp">
       <Filter>Graphic\3D\modelData</Filter>
     </ClCompile>
+    <ClCompile Include="DebugCamera.cpp">
+      <Filter>Camera</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Raki_imguiMgr.h">
@@ -424,6 +427,9 @@
     </ClInclude>
     <ClInclude Include="NY_Model.h">
       <Filter>Graphic\3D\modelData</Filter>
+    </ClInclude>
+    <ClInclude Include="DebugCamera.h">
+      <Filter>Camera</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/RakiEngine_Library/RakiEngine_Library.vcxproj.filters
+++ b/RakiEngine_Library/RakiEngine_Library.vcxproj.filters
@@ -94,6 +94,9 @@
     <Filter Include="Behavior\Navigation">
       <UniqueIdentifier>{a9b11ca7-e184-4d58-a91f-06161dd44417}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Graphic\3D\rendering">
+      <UniqueIdentifier>{c7f329f1-ed45-4794-9319-d95b0dabd3f7}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="Raki_imguiMgr.cpp">
@@ -127,9 +130,6 @@
       <Filter>Graphic\3D</Filter>
     </ClCompile>
     <ClCompile Include="NY_Object3D.cpp">
-      <Filter>Graphic\3D</Filter>
-    </ClCompile>
-    <ClCompile Include="NY_Model.cpp">
       <Filter>Graphic\3D</Filter>
     </ClCompile>
     <ClCompile Include="TexManager.cpp">
@@ -174,12 +174,6 @@
     <ClCompile Include="ParticleManager2D.cpp">
       <Filter>Graphic\2D</Filter>
     </ClCompile>
-    <ClCompile Include="RenderTargetManager.cpp">
-      <Filter>Graphic</Filter>
-    </ClCompile>
-    <ClCompile Include="RTex.cpp">
-      <Filter>Graphic</Filter>
-    </ClCompile>
     <ClCompile Include="FbxLoader.cpp">
       <Filter>Graphic\3D\modelData\FBX</Filter>
     </ClCompile>
@@ -206,9 +200,6 @@
     </ClCompile>
     <ClCompile Include="SpotLight.cpp">
       <Filter>Graphic\3D\lights</Filter>
-    </ClCompile>
-    <ClCompile Include="DifferrdRenderingMgr.cpp">
-      <Filter>Graphic\3D</Filter>
     </ClCompile>
     <ClCompile Include="CameraCalc.cpp">
       <Filter>Math</Filter>
@@ -246,6 +237,18 @@
     <ClCompile Include="FontDrawer.cpp">
       <Filter>Graphic\2D</Filter>
     </ClCompile>
+    <ClCompile Include="DifferrdRenderingMgr.cpp">
+      <Filter>Graphic\3D\rendering</Filter>
+    </ClCompile>
+    <ClCompile Include="RenderTargetManager.cpp">
+      <Filter>Graphic\3D\rendering</Filter>
+    </ClCompile>
+    <ClCompile Include="RTex.cpp">
+      <Filter>Graphic\3D\rendering</Filter>
+    </ClCompile>
+    <ClCompile Include="NY_Model.cpp">
+      <Filter>Graphic\3D\modelData</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Raki_imguiMgr.h">
@@ -277,9 +280,6 @@
     </ClInclude>
     <ClInclude Include="NY_Camera.h">
       <Filter>Camera</Filter>
-    </ClInclude>
-    <ClInclude Include="NY_Model.h">
-      <Filter>Graphic\3D</Filter>
     </ClInclude>
     <ClInclude Include="NY_Object3D.h">
       <Filter>Graphic\3D</Filter>
@@ -335,12 +335,6 @@
     <ClInclude Include="ParticleManager2D.h">
       <Filter>Graphic\2D</Filter>
     </ClInclude>
-    <ClInclude Include="RenderTargetManager.h">
-      <Filter>Graphic</Filter>
-    </ClInclude>
-    <ClInclude Include="RTex.h">
-      <Filter>Graphic</Filter>
-    </ClInclude>
     <ClInclude Include="FbxLoader.h">
       <Filter>Graphic\3D\modelData\FBX</Filter>
     </ClInclude>
@@ -376,9 +370,6 @@
     </ClInclude>
     <ClInclude Include="SpotLight.h">
       <Filter>Graphic\3D\lights</Filter>
-    </ClInclude>
-    <ClInclude Include="DifferrdRenderingMgr.h">
-      <Filter>Graphic\3D</Filter>
     </ClInclude>
     <ClInclude Include="CameraCalc.h">
       <Filter>Math</Filter>
@@ -421,6 +412,18 @@
     </ClInclude>
     <ClInclude Include="FontDrawer.h">
       <Filter>Graphic\2D</Filter>
+    </ClInclude>
+    <ClInclude Include="DifferrdRenderingMgr.h">
+      <Filter>Graphic\3D\rendering</Filter>
+    </ClInclude>
+    <ClInclude Include="RenderTargetManager.h">
+      <Filter>Graphic\3D\rendering</Filter>
+    </ClInclude>
+    <ClInclude Include="RTex.h">
+      <Filter>Graphic\3D\rendering</Filter>
+    </ClInclude>
+    <ClInclude Include="NY_Model.h">
+      <Filter>Graphic\3D\modelData</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/TD4_Game/EngineDebugScene.cpp
+++ b/TD4_Game/EngineDebugScene.cpp
@@ -23,8 +23,8 @@ EngineDebugScene::EngineDebugScene(ISceneChanger* changer)
 	testFBX_YesBone->SetAffineParam(RVector3(20.f, 20.f, 20.f), RVector3(90, 0, 0), RVector3(75.f, 0, -50.f));
 
 	testFBX_NoBone = std::make_shared<Object3d>();
-	testFBX_NoBone.reset(LoadModel_FBXFile("saru"));
-	testFBX_NoBone->SetAffineParam(RVector3(20.5f, 20.5f, 20.5f), RVector3(90, 0, 0), RVector3(0, 0, -50.0f));
+	testFBX_NoBone.reset(LoadModel_FBXFile("hage_1"));
+	testFBX_NoBone->SetAffineParam(RVector3(0.05f, 0.05f, 0.05f), RVector3(90, 0, 0), RVector3(0, 0, -50.0f));
 
 	testobj = std::make_shared<Object3d>();
 	testobj.reset(LoadModel_FBXFile("SpherePBR"));
@@ -76,10 +76,8 @@ void EngineDebugScene::Draw()
 
 void EngineDebugScene::Draw2D()
 {
-	testsp1.DrawExtendSprite(0, 0, 100, 100, { 1,1,1,0.5 });
-	testsp1.DrawExtendSprite(100, 100, 200, 200, { 1,1,1,1 });
-
-	testsp1.Draw();
+	//testsp1.DrawExtendSprite(0, 0, 100, 100, { 1,1,1,0.5 });
+	//testsp2.DrawExtendSprite(100, 100, 100, 100, { 1,1,1,1 });
 }
 
 void EngineDebugScene::DrawImgui()

--- a/TD4_Game/EngineDebugScene.cpp
+++ b/TD4_Game/EngineDebugScene.cpp
@@ -24,7 +24,7 @@ EngineDebugScene::EngineDebugScene(ISceneChanger* changer)
 
 	testFBX_NoBone = std::make_shared<Object3d>();
 	testFBX_NoBone.reset(LoadModel_FBXFile("hage_1"));
-	testFBX_NoBone->SetAffineParam(RVector3(0.05f, 0.05f, 0.05f), RVector3(90, 0, 0), RVector3(0, 0, -50.0f));
+	testFBX_NoBone->SetAffineParam(RVector3(0.1f, 0.1f, 0.1f), RVector3(90, 0, 0), RVector3(0, 0, -50.0f));
 
 	testobj = std::make_shared<Object3d>();
 	testobj.reset(LoadModel_FBXFile("SpherePBR"));

--- a/TD4_Game/Resources/Shaders/OBJShaderHeader.hlsli
+++ b/TD4_Game/Resources/Shaders/OBJShaderHeader.hlsli
@@ -16,7 +16,7 @@ cbuffer cbuff1 : register(b1)
 
 static const int MAX_BONES = 32;
 
-cbuffer skinnning : register(b4)
+cbuffer skinnning : register(b3)
 {
     matrix matSkinning[MAX_BONES];
 }

--- a/TD4_Game/Resources/hage_1/hage_1.blend
+++ b/TD4_Game/Resources/hage_1/hage_1.blend
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ad4c1c025ed0ae429f4294bfa864ce0e6fb79a56445f181f711cde34ed4cebdf
+size 4073536

--- a/TD4_Game/Resources/hage_1/hage_1.fbx
+++ b/TD4_Game/Resources/hage_1/hage_1.fbx
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4765605f53ef77afe10c6e84f7a13c7d79d7e653dc94d8d9273042424728d5c0
+oid sha256:27b59a97102381d3050ef37f9314c53a7ff45da84fde8e9afc9fc37c692c84a7
 size 871644

--- a/TD4_Game/Resources/hage_1/hage_1.fbx
+++ b/TD4_Game/Resources/hage_1/hage_1.fbx
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:27b59a97102381d3050ef37f9314c53a7ff45da84fde8e9afc9fc37c692c84a7
+oid sha256:4765605f53ef77afe10c6e84f7a13c7d79d7e653dc94d8d9273042424728d5c0
 size 871644

--- a/TD4_Game/imgui.ini
+++ b/TD4_Game/imgui.ini
@@ -4,12 +4,12 @@ Size=400,400
 Collapsed=0
 
 [Window][fbx control]
-Pos=1000,445
-Size=294,271
+Pos=1000,-1
+Size=294,208
 Collapsed=0
 
 [Window][light ctrl]
-Pos=991,7
-Size=285,300
+Pos=-3,3
+Size=285,155
 Collapsed=0
 

--- a/TD4_Game/imgui.ini
+++ b/TD4_Game/imgui.ini
@@ -4,7 +4,7 @@ Size=400,400
 Collapsed=0
 
 [Window][fbx control]
-Pos=1000,-1
+Pos=968,10
 Size=294,208
 Collapsed=0
 

--- a/TD4_Game/main.cpp
+++ b/TD4_Game/main.cpp
@@ -35,7 +35,7 @@ int WINAPI WinMain(HINSTANCE, HINSTANCE, LPSTR, int)
 	rakiWinApp->CreateGameWindow();
 
 	//エンジン側のエラー、警告を無視しない設定にするときは、この関数の第二引数にtrueを渡すと良い
-	Raki_DX12B::Get()->Initialize(rakiWinApp, false);
+	Raki_DX12B::Get()->Initialize(rakiWinApp, true);
 
 	myImgui::InitializeImGui(Raki_DX12B::Get()->GetDevice(), Raki_WinAPI::GetHWND());
 


### PR DESCRIPTION
# Engine更新

## D3Dの警告とエラー修正

以前から出力ログに大量に出ていたD3Dのエラー、警告を解消しました。
出力ログに出てくるのは現状リーク系の警告だけのはずです
それ以外の警告があった場合は報告してください。

## FBX検証

いろいろ試したけどライティングバグは不明
質問のための準備する