### PR TITLE
Engine

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,3 +6,4 @@
 *.jpg filter=lfs diff=lfs merge=lfs -text
 *.exe filter=lfs diff=lfs merge=lfs -text
 *.blend filter=lfs diff=lfs merge=lfs -text
+*.wav filter=lfs diff=lfs merge=lfs -text

--- a/RakiEngine_Library/Audio.cpp
+++ b/RakiEngine_Library/Audio.cpp
@@ -120,6 +120,7 @@ void Audio::PlayLoadedSound(SoundData &soundData, bool isSerialPlay)
 
     if (soundData.isPause) {
         result = soundData.source->Start();
+        soundData.isPause = false;
     }
     else {
         soundData.source->GetState(&state);
@@ -137,8 +138,6 @@ void Audio::PlayLoadedSound(SoundData &soundData, bool isSerialPlay)
         result = soundData.source->SubmitSourceBuffer(&soundData.buf);
         result = soundData.source->Start();
     }
-
-
 }
 
 void Audio::PauseLoadedSound(SoundData &soundData)
@@ -149,7 +148,6 @@ void Audio::PauseLoadedSound(SoundData &soundData)
     HRESULT result;
 
     //波形データ停止
-    //result = soundData.source->SubmitSourceBuffer(&soundData.buf);
     result = soundData.source->Stop();
 }
 
@@ -162,7 +160,6 @@ void Audio::StopLoadedSound(SoundData &soundData)
     //波形データ停止
     result = soundData.source->Stop();
     result = soundData.source->FlushSourceBuffers();
-    //result = soundData.source->SubmitSourceBuffer(&soundData.buf);
 }
 
 void Audio::SetMasterVolume(float volume)

--- a/RakiEngine_Library/Audio.h
+++ b/RakiEngine_Library/Audio.h
@@ -39,16 +39,18 @@ struct SoundData {
 	IXAudio2SourceVoice *source;
 	//バッファ
 	XAUDIO2_BUFFER buf{};
+	//音量
+	float volume = 1.0f;
 };
 
 
 class Audio
 {
-public:
+private:
 
 	static ComPtr<IXAudio2>        xAudio2;
 	static IXAudio2MasteringVoice *masterVoice;
-	static float volume;
+	static float mastervolume;
 
 public:
 
@@ -58,7 +60,7 @@ public:
 		//マスターボイス作成
 		result = xAudio2->CreateMasteringVoice(&masterVoice);
 		//ボリューム初期化(50%)
-		volume = 0.5f;
+		mastervolume = 0.5f;
 	}
 
 	//初期化
@@ -68,6 +70,7 @@ public:
 	static SoundData LoadSound_wav(const char *filename);
 	//サウンドデータのアンロード
 	static void UnloadSound(SoundData *data);
+	
 
 	//ループの設定(0~254でループ回数を指定。255の場合無限ループ。それ以外は無効)
 	static void SetPlayRoopmode(SoundData &soundData,int roopCount);
@@ -78,5 +81,9 @@ public:
 	//停止
 	static void StopLoadedSound(SoundData &soundData);
 
+	//マスター音量変更
+	static void SetMasterVolume(float volume);
+	//音データ音量変更
+	static void SetSoundDataVolume(SoundData& data, float volume);
 };
 

--- a/RakiEngine_Library/Audio.h
+++ b/RakiEngine_Library/Audio.h
@@ -41,6 +41,8 @@ struct SoundData {
 	XAUDIO2_BUFFER buf{};
 	//音量
 	float volume = 1.0f;
+	//一時停止フラグ
+	bool isPause = false;
 };
 
 
@@ -75,9 +77,9 @@ public:
 	//ループの設定(0~254でループ回数を指定。255の場合無限ループ。それ以外は無効)
 	static void SetPlayRoopmode(SoundData &soundData,int roopCount);
 	//再生
-	static void PlayLoadedSound(const SoundData &soundData,bool isSerialPlay = false);
+	static void PlayLoadedSound(SoundData &soundData,bool isSerialPlay = false);
 	//一時停止
-	static void PauseLoadedSound(const SoundData &soundData);
+	static void PauseLoadedSound(SoundData &soundData);
 	//停止
 	static void StopLoadedSound(SoundData &soundData);
 

--- a/RakiEngine_Library/enginemanual/音関連機能ドキュメント.md
+++ b/RakiEngine_Library/enginemanual/音関連機能ドキュメント.md
@@ -1,0 +1,153 @@
+# 音関連機能ドキュメント
+
+## 目次
+
+- 概要
+- 関数リファレンス
+    - Audio.h
+        - [LoadSound_wav](https://www.notion.so/cf48231389e04e78afc78adaed99d121?pvs=21)
+        - [UnloadSound](https://www.notion.so/cf48231389e04e78afc78adaed99d121?pvs=21)
+        - [SetPlayRoopmode](https://www.notion.so/cf48231389e04e78afc78adaed99d121?pvs=21)
+        - [PlayLoadedSound](https://www.notion.so/cf48231389e04e78afc78adaed99d121?pvs=21)
+        - [PauseLoadedSound](https://www.notion.so/cf48231389e04e78afc78adaed99d121?pvs=21)
+        - [StopLoadedSound](https://www.notion.so/cf48231389e04e78afc78adaed99d121?pvs=21)
+        - [SetMasterVolume](https://www.notion.so/cf48231389e04e78afc78adaed99d121?pvs=21)
+        - [SetSoundDataVolume](https://www.notion.so/cf48231389e04e78afc78adaed99d121?pvs=21)
+
+---
+
+## 概要
+
+音関連の処理を行うクラスです。
+ヘッダーは Audio.h
+cppは          Audio.cpp
+
+```cpp
+#include <Audio.h>
+```
+
+現状.wavファイル以外の読み込みに対応していません。
+mp3などのファイルは変換器を使って.wavにしてください。
+
+このクラスでは.wavの読み込み、再生、一時停止、停止、削除ができます。
+
+---
+
+## 関数リファレンス
+
+### static SoundData LoadSound_wav(const char *filename);
+
+wavファイルをロードします。
+
+**引数**
+
+- **const char *filename**
+ファイルのパス
+
+**戻り値**
+
+- ロードした音データをSoundData型で返します。
+これで取得したデータを再生、停止、削除関数に渡して使用します。
+
+---
+
+### static void UnloadSound(SoundData *data);
+
+ロードした音データを削除します。
+
+引数
+
+- **SoundData *data**
+削除する音データ
+
+---
+
+### static void SetPlayRoopmode(SoundData &soundData,int roopCount);
+
+ロードした音データのループ設定を変更します。
+
+引数
+
+- **SoundData &soundData**
+変更する音データの参照
+- **int roopCount**
+ループさせる回数。設定できる範囲は0 ~ 254。
+255を設定した場合は無限ループになる。
+それ以外の値は無効。
+
+---
+
+### static void PlayLoadedSound(SoundData &soundData,
+                                                 bool isSerialPlay = false);
+
+音を再生します。ループの設定が入っているときはその回数分ループ再生します。
+
+引数で指定したSoundData がすでに再生されている場合はそのまま再生します。
+ただし、isSerialPlayをtrueにすると、その音が再生中に呼び出されたとき、
+その音を停止したあと再生されます。つまり、連続で最初から再生できます。
+これは、ボタン連打などで連続で再生したいSEを使うときに役立ちます。
+
+引数
+
+- **const SoundData &soundData**
+再生したい音データ
+- **bool isSerialPlay**
+soundDataで指定したデータが再生中の場合、連続で最初から再生するかを指定する
+フラグです。
+
+---
+
+### static void PauseLoadedSound(SoundData &soundData);
+
+音を一時停止します。これで一時停止した音を再び再生すると、
+一時停止した時点から再生されます。
+
+引数
+
+- **const SoundData &soundDat**a
+一時停止する音の参照
+
+---
+
+### static void StopLoadedSound(SoundData &soundData);
+
+音を停止します。これで停止した音を再び再生すると、最初から再生されます。
+
+引数
+
+- **const SoundData &soundData**
+停止する音の参照
+
+---
+
+### static void SetMasterVolume(float volume);
+
+すべての音データ再生時にかかる音量の補正値を変更します。
+指定できる範囲は0.0 ~ 1.0です。それ以外は適正な値に変更されます。
+なお、すでに再生中の音は補正されません。一時停止などしてください。
+
+引数
+
+- **float volume**
+0.0 ~ 1.0の範囲で渡された値でmasterVolumeを変更します
+
+---
+
+### static void SetSoundDataVolume(SoundData& data, float volume);
+
+渡された音データの音量を変更します。
+指定できる範囲は0.0 ~ 1.0です。それ以外は適正な値に変更されます。
+
+引数
+
+- **SoundData& data**
+音量を変更する音の参照
+- **float volume**
+0.0 ~ 1.0の範囲で渡された値で音量を変更します
+
+---
+
+## その他
+
+EngineDebugSceneに音関連の処理を記述してます。
+ImGuiで操作できるので参考にしてみてください。

--- a/RakiEngine_Library/enginemanual/音関連機能ドキュメント.md
+++ b/RakiEngine_Library/enginemanual/音関連機能ドキュメント.md
@@ -1,18 +1,20 @@
 # 音関連機能ドキュメント
 
+notion版：[https://flint-finch-309.notion.site/cf48231389e04e78afc78adaed99d121?pvs=4](https://www.notion.so/cf48231389e04e78afc78adaed99d121?pvs=21)
+
 ## 目次
 
 - 概要
 - 関数リファレンス
     - Audio.h
-        - [LoadSound_wav](https://www.notion.so/cf48231389e04e78afc78adaed99d121?pvs=21)
-        - [UnloadSound](https://www.notion.so/cf48231389e04e78afc78adaed99d121?pvs=21)
-        - [SetPlayRoopmode](https://www.notion.so/cf48231389e04e78afc78adaed99d121?pvs=21)
-        - [PlayLoadedSound](https://www.notion.so/cf48231389e04e78afc78adaed99d121?pvs=21)
-        - [PauseLoadedSound](https://www.notion.so/cf48231389e04e78afc78adaed99d121?pvs=21)
-        - [StopLoadedSound](https://www.notion.so/cf48231389e04e78afc78adaed99d121?pvs=21)
-        - [SetMasterVolume](https://www.notion.so/cf48231389e04e78afc78adaed99d121?pvs=21)
-        - [SetSoundDataVolume](https://www.notion.so/cf48231389e04e78afc78adaed99d121?pvs=21)
+        - [LoadSound_wav](#static-sounddata-loadsound_wavconst-char-filename)
+        - [UnloadSound](#static-void-unloadsoundsounddata-data)
+        - [SetPlayRoopmode](#static-void-setplayroopmodesounddata-sounddataint-roopcount)
+        - [PlayLoadedSound](#static-void-playloadedsoundsounddata-sounddata)
+        - [PauseLoadedSound](#static-void-pauseloadedsoundsounddata-sounddata)
+        - [StopLoadedSound](#static-void-stoploadedsoundsounddata-sounddata)
+        - [SetMasterVolume](#static-void-setmastervolumefloat-volume)
+        - [SetSoundDataVolume](#static-void-setsounddatavolumesounddata-data-float-volume)
 
 ---
 
@@ -77,8 +79,7 @@ wavファイルをロードします。
 
 ---
 
-### static void PlayLoadedSound(SoundData &soundData,
-                                                 bool isSerialPlay = false);
+### static void PlayLoadedSound(SoundData &soundData,bool isSerialPlay = false);
 
 音を再生します。ループの設定が入っているときはその回数分ループ再生します。
 

--- a/TD4_Game/EngineDebugScene.cpp
+++ b/TD4_Game/EngineDebugScene.cpp
@@ -37,6 +37,13 @@ EngineDebugScene::EngineDebugScene(ISceneChanger* changer)
 	RVector3 up(0.f, 1.f, 0.f);
 	NY_Camera::Get()->SetViewStatusEyeTargetUp(eye, target, up);
 
+	//音ロード
+	testSE = Audio::LoadSound_wav("Resources/don.wav");
+	testBGM = Audio::LoadSound_wav("Resources/kari.wav");
+
+	//無限ループ
+	Audio::SetPlayRoopmode(testBGM, 255);
+
 	q1 = quaternion(1, 2, 3, 4);
 	q2 = quaternion(2, 3, 4, 1);
 
@@ -64,6 +71,8 @@ void EngineDebugScene::Update()
 	else if (Input::isKeyTrigger(DIK_E)) { testEase.Reset(); }
 
 	testobject->SetAffineParamTranslate(testEase.Update());
+
+	if (Input::isKeyTrigger(DIK_O)) { Audio::PlayLoadedSound(testSE, true); }
 }
 
 void EngineDebugScene::Draw()
@@ -115,6 +124,24 @@ void EngineDebugScene::DrawImgui()
 	ImGui::SliderFloat("light z", &lightdir.z, -1.f, 1.0f);
 
 	DirectionalLight::SetLightDir(lightdir.x, lightdir.y, lightdir.z);
+
+	myImgui::EndDrawImGui();
+
+	myImgui::StartDrawImGui("Audio Control", 150, 300);
+
+	if (ImGui::Button("PLAY")) {
+		Audio::PlayLoadedSound(testBGM);
+	}
+	if (ImGui::Button("STOP")) {
+		Audio::StopLoadedSound(testBGM);
+	}
+	if (ImGui::Button("PAUSE")) {
+		Audio::PauseLoadedSound(testBGM);
+	}
+
+	static float masterVolume = 0.5f;
+	ImGui::SliderFloat("master volume", &masterVolume, 0.0f, 1.0f);
+	Audio::SetMasterVolume(masterVolume);
 
 	myImgui::EndDrawImGui();
 

--- a/TD4_Game/EngineDebugScene.h
+++ b/TD4_Game/EngineDebugScene.h
@@ -6,6 +6,7 @@
 #include <Raki_Input.h>
 
 #include <CameraCalc.h>
+#include <Audio.h>
 
 //エンジン側検証用シーン
 //このクラスもいじらないこと
@@ -45,5 +46,9 @@ public:
     RQuaternion q1, q2;
 
     RVector3 lightdir;
+
+    //音
+    SoundData testSE;
+    SoundData testBGM;
 };
 

--- a/TD4_Game/Resources/don.wav
+++ b/TD4_Game/Resources/don.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b003d0a834d1dd7699d8302376237e53f1e2c34ececf124be22014cce52fca5d
+size 401000

--- a/TD4_Game/Resources/kari.wav
+++ b/TD4_Game/Resources/kari.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:45162f4100f6f7d15fca0a2986301c14dae9633cbe5a2580d492012f077dc9ef
+size 1133056

--- a/TD4_Game/imgui.ini
+++ b/TD4_Game/imgui.ini
@@ -13,3 +13,8 @@ Pos=-4,2
 Size=285,155
 Collapsed=0
 
+[Window][Audio Control]
+Pos=1036,252
+Size=150,300
+Collapsed=0
+


### PR DESCRIPTION
# Engine更新

## Audioクラス機能追加

マスター音量と各音の音量の調整機能を追加
マスター音量は、各音の再生時、各音に指定された音量に乗算されます。
例えばマスター音量が0.5、音Aの音量が1.0のとき、
0.5 * 1.0 = 0.5 となり、音Aは0.5の音量で再生されます。

関数
```
static void Audio::SetMasterVolume(float volume)

static void Audio::SetSoundDataVolume(SoundData& data, float volume)
```

## 修正

PauseLoadedSound(a)を使用したあとに再びPlayLoadedSound(a)を実行したとき、
aが再生されない問題を修正しました。

## ドキュメント追加

enginemanualにAudioのドキュメント追加しました。
音関連の実装の参考にしてください。
notion版もあります。そっちのほうが見やすいかもしれません。


