### PR TITLE
Spriteに数値表示用関数追加

### DIFF
--- a/RakiEngine_Library/RakiEngine_Library.vcxproj
+++ b/RakiEngine_Library/RakiEngine_Library.vcxproj
@@ -74,6 +74,7 @@
     <ClCompile Include="ParticleManager.cpp" />
     <ClCompile Include="ParticleManager2D.cpp" />
     <ClCompile Include="Quaternion.cpp" />
+    <ClCompile Include="RakiUtility.cpp" />
     <ClCompile Include="Raki_DX12B.cpp" />
     <ClCompile Include="Raki_imguiMgr.cpp" />
     <ClCompile Include="Raki_Input.cpp" />
@@ -133,6 +134,7 @@
     <ClInclude Include="ParticleManager.h" />
     <ClInclude Include="ParticleManager2D.h" />
     <ClInclude Include="Quaternion.h" />
+    <ClInclude Include="RakiUtility.h" />
     <ClInclude Include="Raki_DX12B.h" />
     <ClInclude Include="Raki_imguiMgr.h" />
     <ClInclude Include="Raki_Input.h" />

--- a/RakiEngine_Library/RakiEngine_Library.vcxproj.filters
+++ b/RakiEngine_Library/RakiEngine_Library.vcxproj.filters
@@ -252,6 +252,9 @@
     <ClCompile Include="DebugCamera.cpp">
       <Filter>Camera</Filter>
     </ClCompile>
+    <ClCompile Include="RakiUtility.cpp">
+      <Filter>ソース ファイル</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Raki_imguiMgr.h">
@@ -430,6 +433,9 @@
     </ClInclude>
     <ClInclude Include="DebugCamera.h">
       <Filter>Camera</Filter>
+    </ClInclude>
+    <ClInclude Include="RakiUtility.h">
+      <Filter>utility</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/RakiEngine_Library/RakiUtility.cpp
+++ b/RakiEngine_Library/RakiUtility.cpp
@@ -1,0 +1,18 @@
+#include "RakiUtility.h"
+
+int rutility::GetDigits(float value, int left, int right)
+{
+    double mod_value;
+    int result;
+
+    /* –‘O‚Éâ‘Î’l‚ğ‹‚ß‚Ä‚¨‚­ */
+    value = fabs(value);
+
+    /* nŒ…–ÚˆÈ‰º‚ÌŒ…‚ğæ“¾ */
+    mod_value = fmod(value, pow(10, right + 1));
+
+    /* mŒ…–ÚˆÈã‚ÌŒ…‚ğæ“¾ */
+    result = int(mod_value / pow(10, left));
+
+    return result;
+}

--- a/RakiEngine_Library/RakiUtility.h
+++ b/RakiEngine_Library/RakiUtility.h
@@ -1,0 +1,20 @@
+#pragma once
+#include <iostream>
+#include <cstdlib>
+#include <math.h>
+
+//既存の関数とかぶらないように
+//種類が増えたらこの中からさらに名前空間分けする
+namespace rutility
+{
+
+	//数値から特定の桁を整数で出力（桁は、整数第1位を0、整数部は正、小数部は負で示す）
+	int GetDigits(float value, int left, int right);
+
+
+
+
+
+}
+
+

--- a/RakiEngine_Library/Sprite.cpp
+++ b/RakiEngine_Library/Sprite.cpp
@@ -5,6 +5,8 @@
 #include "RenderTargetManager.h"
 
 #include "Raki_DX12B.h"
+#include "RakiUtility.h"
+
 
 //スプライト加工カラー
 DirectX::XMFLOAT4 Sprite::sprite_color = { 1.0f,1.0f,1.0f,1.0f };
@@ -844,6 +846,63 @@ void Sprite::DrawRTexSprite(int handle, float x1, float y1, float x2, float y2, 
     spdata->insWorldMatrixes.push_back(ins);
 
     DrawRenderTexture(handle);
+}
+
+void Sprite::DrawNumSprite(float startX, float startY, float sizeX, float sizeY, int value, DirectX::XMFLOAT4 color)
+{
+    //数値スプライトを描画する
+
+    //数値の桁数を取得
+    int digit = int(std::to_string(value).length());
+
+    //桁数分ループ
+    for (int i = 0; i < digit; i++) {
+
+        int n = digit - i - 1;
+
+        uvOffsetHandle = rutility::GetDigits(float(value), n, n);
+
+        float offsetX = float(sizeX * float(digit));
+
+        float lx = startX + (offsetX - (sizeX * float(digit - i)));
+        float ly = startY;
+        float rx = startX + (offsetX - (sizeX * float(digit - i))) + sizeX;
+        float ry = startY + sizeY;
+
+        DrawExtendSprite(lx, ly, rx, ry, color);
+    }
+
+}
+
+void Sprite::DrawNumSpriteZeroFill(float startX, float startY, float sizeX, float sizeY, int value, int maxDigit, DirectX::XMFLOAT4 color)
+{
+    //数値の桁数を取得
+    int digit = int(std::to_string(value).length());
+
+
+    //桁数分ループ
+    for (int i = 0; i < maxDigit; i++) {
+
+        //現在の桁
+        int n = maxDigit - i - 1;
+        //数値の桁数
+        int d = digit - 1;
+        if (n > d) {
+            uvOffsetHandle = 0;
+        }
+        else {
+            uvOffsetHandle = rutility::GetDigits(float(value), n, n);
+        }
+
+        float offsetX = float(sizeX * float(maxDigit));
+
+        float lx = startX + (offsetX - (sizeX * float(maxDigit - i)));
+        float ly = startY;
+        float rx = startX + (offsetX - (sizeX * float(maxDigit - i))) + sizeX;
+        float ry = startY + sizeY;
+
+        DrawExtendSprite(lx, ly, rx, ry, color);
+    }
 }
 
 bool Sprite::IsCreated()

--- a/RakiEngine_Library/Sprite.h
+++ b/RakiEngine_Library/Sprite.h
@@ -67,6 +67,9 @@ public:
 
 	void DrawRTexSprite(int handle, float x1, float y1, float x2, float y2, float angle, DirectX::XMFLOAT4 freedata01 = { 1,1,1,1 });
 
+	void DrawNumSprite(float startX, float startY, float sizeX, float sizeY, int value, DirectX::XMFLOAT4 color = { 1.f,1.f,1.f,1.f });
+
+	void DrawNumSpriteZeroFill(float startX, float startY, float sizeX, float sizeY, int value, int maxDigit, DirectX::XMFLOAT4 color = { 1.f,1.f,1.f,1.f });
 	//テクスチャのもとのサイズ
 	XMFLOAT2 TEXTURE_DEFAULT_SIZE;
 

--- a/TD4_Game/EngineDebugScene.cpp
+++ b/TD4_Game/EngineDebugScene.cpp
@@ -45,6 +45,8 @@ EngineDebugScene::EngineDebugScene(ISceneChanger* changer)
 	testSE = Audio::LoadSound_wav("Resources/don.wav");
 	testBGM = Audio::LoadSound_wav("Resources/kari.wav");
 
+	testNum.CreateAndSetDivisionUVOffsets(10, 10, 1, 64, 64, TexManager::LoadTexture("Resources/Score.png"));
+
 	//ñ≥å¿ÉãÅ[Év
 	Audio::SetPlayRoopmode(testBGM, 255);
 
@@ -94,6 +96,13 @@ void EngineDebugScene::Draw2D()
 {
 	//testsp1.DrawExtendSprite(0, 0, 100, 100, { 1,1,1,0.5 });
 	//testsp2.DrawExtendSprite(100, 100, 100, 100, { 1,1,1,1 });
+
+	testNum.DrawSprite(0, 100);
+
+	testNum.DrawNumSpriteZeroFill(0, 0, 32, 32, dval, 10);
+	testNum.uvOffsetHandle = 1;
+
+	testNum.Draw();
 }
 
 void EngineDebugScene::DrawImgui()
@@ -116,6 +125,9 @@ void EngineDebugScene::DrawImgui()
 		DirectionalLight::GetLightDir().y, DirectionalLight::GetLightDir().z);
 
 	ImGui::SliderFloat("camrot", &camrot, 0.f, 2.0f);
+
+	ImGui::SliderInt("num", &testNum.uvOffsetHandle, 0, 9);
+	ImGui::SliderInt("dValue", &dval, -200000000, 200000000);
 
 	myImgui::EndDrawImGui();
 

--- a/TD4_Game/EngineDebugScene.h
+++ b/TD4_Game/EngineDebugScene.h
@@ -50,5 +50,8 @@ public:
     //‰¹
     SoundData testSE;
     SoundData testBGM;
+
+    Sprite testNum;
+    int dval = 0;
 };
 

--- a/TD4_Game/imgui.ini
+++ b/TD4_Game/imgui.ini
@@ -4,17 +4,17 @@ Size=400,400
 Collapsed=0
 
 [Window][fbx control]
-Pos=1005,1
-Size=294,208
+Pos=892,-2
+Size=351,263
 Collapsed=0
 
 [Window][light ctrl]
-Pos=-4,2
+Pos=569,140
 Size=285,155
 Collapsed=0
 
 [Window][Audio Control]
-Pos=1036,252
+Pos=1075,378
 Size=150,300
 Collapsed=0
 


### PR DESCRIPTION
# engine更新

## Sprite機能追加

Spriteに新関数を追加
```
void DrawNumSprite(float startX, float startY, float sizeX, float sizeY, int value, DirectX::XMFLOAT4 color = { 1.f,1.f,1.f,1.f });
```
数値を表示するための関数です。
以前はuvoffsetを1桁ごとに操作して数値を表示するという
煩わしさの極みクソ仕様でしたが、その手の処理をこれ一行で済ませられます。

valueにint型数値を入力することで、数値用にロードしたSpriteであれば
intの範囲内で好きな値を表示可能です。
```
void DrawNumSpriteZeroFill(float startX, float startY, float sizeX, float sizeY, int value, int maxDigit, DirectX::XMFLOAT4 color = { 1.f,1.f,1.f,1.f });
```
こちらは表示桁を絞れます。
maxdigitで指定した桁数より多い数値は、上位桁から表示を省略されます
（例：314,159,265　maxdigit = 6の場合、表示されるのは159,625）

maxdigitより少ない桁数の場合、上位桁を0で表示します
（例：114,514 maxdigit = 12の場合、000,000,114,514）

## RakiUtilityファイル追加

あると良さそうだけど、あんま使わなさそうな関数を纏めるためのファイルです
現状、数値から一定の範囲の桁を取り出す関数のみあります。

ほしい機能があれば相談してください。些細なものでもいいです。
（場合によってはエンジンの機能にしたりもします）


