### PR TITLE
Engine

### DIFF
--- a/RakiEngine_Library/FbxLoader.cpp
+++ b/RakiEngine_Library/FbxLoader.cpp
@@ -298,9 +298,6 @@ void FbxLoader::ParseMaterial(fbxModel* model, FbxNode* node)
             }
         }
 
-        if (!textureLoaded) {
-            model->material.texNumber = TexManager::LoadTexture(baseDir + defaultTexName);
-        }
     }
 
     if (!textureLoaded) { model->material.texNumber = TexManager::LoadTexture(baseDir + defaultTexName); }

--- a/RakiEngine_Library/GraphicManager.cpp
+++ b/RakiEngine_Library/GraphicManager.cpp
@@ -1,0 +1,68 @@
+#include "GraphicManager.h"
+#include "Raki_WinAPI.h"
+
+void GraphicManager::Init()
+{
+	//各フェーズの初期化
+	NY_Object3DManager::Get()->CreateObject3DManager();
+	SpriteManager::Get()->CreateSpriteManager(Raki_DX12B::Get()->GetDevice(),
+		Raki_DX12B::Get()->GetGCommandList(),
+		Raki_WinAPI::window_width,
+		Raki_WinAPI::window_height);
+
+	TexManager::InitTexManager();
+
+	myImgui::InitializeImGui(Raki_DX12B::Get()->GetDevice(), Raki_WinAPI::GetHWND());
+
+	//ディファードレンダリング初期化
+	m_deferredRender.Init(RAKI_DX12B_DEV, RAKI_DX12B_CMD);
+
+	//パーティクル描画初期化
+	m_particleDrawMgr.Init();
+}
+
+void GraphicManager::StartDraw()
+{
+	//レンダーターゲットクリア、描画開始
+	RenderTargetManager::GetInstance()->CrearAndStartDraw();
+}
+
+void GraphicManager::StartDeferredDraw()
+{
+	//GBuffer描画開始
+	NY_Object3DManager::Get()->SetCommonBeginDrawObject3D();
+}
+
+void GraphicManager::EndDefferdDraw()
+{
+	//GBuffer描画終了
+	NY_Object3DManager::Get()->CloseDrawObject3D();
+	//ディファードレンダリング実行（シャドウマップ未使用）
+	m_deferredRender.Rendering(&NY_Object3DManager::Get()->m_gBuffer, nullptr);
+}
+
+void GraphicManager::StartForwardDraw3D()
+{
+	//フォワードレンダリングのシェーダーを用意するまではこの関数は意味無し
+}
+
+void GraphicManager::StartParticleDraw3D()
+{
+	//
+	m_particleDrawMgr.SetCommonBeginDrawParticle3D();
+}
+
+void GraphicManager::StartParticleDraw2D()
+{
+	m_particleDrawMgr.SetCommonBeginDrawParticle2D();
+}
+
+void GraphicManager::StartSpriteDraw()
+{
+	SpriteManager::Get()->SetCommonBeginDraw();
+}
+
+void GraphicManager::FinishDraw()
+{
+	RenderTargetManager::GetInstance()->SwapChainBufferFlip();
+}

--- a/RakiEngine_Library/GraphicManager.h
+++ b/RakiEngine_Library/GraphicManager.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include "NY_Object3DMgr.h"
+#include "SpriteManager.h"
+#include "RenderTargetManager.h"
+#include "DifferrdRenderingMgr.h"
+#include "ParticleManager.h"
+#include "RTex.h"
+
+//•`‰æ‡‚ğw’è‚µ‚Ä•`‰æ‚ğŒø—¦‰»
+class GraphicManager
+{
+public:
+	GraphicManager() = default;
+	~GraphicManager() = default;
+
+	void Init();
+
+	void StartDraw();
+
+	void StartDeferredDraw();
+
+	void EndDefferdDraw();
+
+	void StartForwardDraw3D();
+
+	void StartParticleDraw3D();
+
+	void StartParticleDraw2D();
+
+	void StartSpriteDraw();
+
+	void FinishDraw();
+
+private:
+
+	DiferredRenderingMgr m_deferredRender;
+
+	ParticleDrawManager m_particleDrawMgr;
+
+
+
+
+
+};
+

--- a/RakiEngine_Library/NY_Model.h
+++ b/RakiEngine_Library/NY_Model.h
@@ -67,6 +67,7 @@ public:
 
 	Model3D() {};
 	~Model3D() {
+		TexManager::DeleteTexture(material.texNumber);
 	}
 
 	//----------ファイルを読み込んでモデルデータを作る関数群----------//

--- a/RakiEngine_Library/NY_Object3D.h
+++ b/RakiEngine_Library/NY_Object3D.h
@@ -90,9 +90,7 @@ public:
 		fbxmodel = make_shared<fbxModel>();
 	};
 	~Object3d() {
-		if (model) {
-
-		}
+		
 	}
 
 	//オブジェクトの初期化

--- a/RakiEngine_Library/ParticleManager.cpp
+++ b/RakiEngine_Library/ParticleManager.cpp
@@ -3,6 +3,8 @@
 #include "ParticleManager.h"
 #include "Raki_DX12B.h"
 #include "TexManager.h"
+#include "NY_random.h"
+#include "RakiUtility.h"
 
 #include <iostream>
 
@@ -124,6 +126,7 @@ void ParticleManager::Update() {
 
 void ParticleManager::Draw(UINT drawTexNum)
 {
+
 	UINT drawNum = (UINT)std::distance(grains.begin(), grains.end());
 	if (drawNum > MAX_VERTEX) {
 		drawNum = MAX_VERTEX;
@@ -134,10 +137,10 @@ void ParticleManager::Draw(UINT drawTexNum)
 		return;
 	}
 
-	// パイプラインステートの設定
-	cmd->SetPipelineState(pipeline.Get());
-	// ルートシグネチャの設定
-	cmd->SetGraphicsRootSignature(rootsig.Get());
+	//// パイプラインステートの設定
+	//cmd->SetPipelineState(pipeline.Get());
+	//// ルートシグネチャの設定
+	//cmd->SetGraphicsRootSignature(rootsig.Get());
 	// プリミティブ形状を設定
 	cmd->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_POINTLIST);
 
@@ -165,7 +168,15 @@ void ParticleManager::Add(ParticleGrainState pgState)
 	grains.emplace_front();
 	//追加した要素の参照
 	Particle &p = grains.front();
-	p.pos = pgState.position;			//初期位置
+
+	if (pgState.isRandomSpawn) {
+		p.pos = rutility::randomRV3(
+			pgState.position + pgState.position_spawnRange1,
+			pgState.position + pgState.position_spawnRange2);
+	}
+	else {
+		p.pos = pgState.position;			//初期位置
+	}
 	p.vel = pgState.vel;			//速度
 	p.acc = pgState.acc;			//加速度
 	p.s_scale = pgState.scale_start; //開始時のスケールサイズ
@@ -812,9 +823,9 @@ void ParticleDrawManager::Init()
 
 void ParticleDrawManager::SetCommonBeginDrawParticle3D()
 {
-	
-
 	RAKI_DX12B_CMD->SetPipelineState(pipeline3D.Get());
+
+	RAKI_DX12B_CMD->SetGraphicsRootSignature(rootsig.Get());
 }
 
 void ParticleDrawManager::SetCommonBeginDrawParticle2D()

--- a/RakiEngine_Library/ParticleManager.cpp
+++ b/RakiEngine_Library/ParticleManager.cpp
@@ -297,8 +297,6 @@ void ParticleManager::InitializeGraphicsPipeline(bool is2d) {
 	ComPtr<ID3DBlob> gsBlob;	// ジオメトリシェーダオブジェクト
 	ComPtr<ID3DBlob> errorBlob; // エラーオブジェクト
 
-
-
 	if (is2d) {
 		// 頂点シェーダの読み込みとコンパイル
 		result = D3DCompileFromFile(
@@ -322,7 +320,6 @@ void ParticleManager::InitializeGraphicsPipeline(bool is2d) {
 			OutputDebugStringA(errstr.c_str());
 			exit(1);
 		}
-
 		// ピクセルシェーダの読み込みとコンパイル
 		result = D3DCompileFromFile(
 			L"Resources/Shaders/Particle2dPS.hlsl",	// シェーダファイル名
@@ -345,7 +342,6 @@ void ParticleManager::InitializeGraphicsPipeline(bool is2d) {
 			OutputDebugStringA(errstr.c_str());
 			exit(1);
 		}
-
 		// ジオメトリシェーダの読み込みとコンパイル
 		result = D3DCompileFromFile(
 			L"Resources/Shaders/Particle2dGS.hlsl",	// シェーダファイル名
@@ -368,14 +364,8 @@ void ParticleManager::InitializeGraphicsPipeline(bool is2d) {
 			OutputDebugStringA(errstr.c_str());
 			exit(1);
 		}
-
-
-
 	}
 	else {
-
-
-
 		// 頂点シェーダの読み込みとコンパイル
 		result = D3DCompileFromFile(
 			L"Resources/Shaders/ParticleVS.hlsl",	// シェーダファイル名
@@ -611,4 +601,223 @@ void ParticleManager::CreateModel() {
 	vbview.StrideInBytes = sizeof(PVertex);
 
 
+}
+
+void ParticleDrawManager::Init()
+{
+	ComPtr<ID3DBlob> vsBlob; // 頂点シェーダオブジェクト
+	ComPtr<ID3DBlob> psBlob;	// ピクセルシェーダオブジェクト
+	ComPtr<ID3DBlob> gsBlob;	// ジオメトリシェーダオブジェクト
+	ComPtr<ID3DBlob> errorBlob; // エラーオブジェクト
+	
+#pragma region SHADER_COMPILE
+	// 頂点シェーダの読み込みとコンパイル
+	HRESULT result = D3DCompileFromFile(
+		L"Resources/Shaders/ParticleVS.hlsl",	// シェーダファイル名
+		nullptr,
+		D3D_COMPILE_STANDARD_FILE_INCLUDE, // インクルード可能にする
+		"main", "vs_5_0",	// エントリーポイント名、シェーダーモデル指定
+		D3DCOMPILE_DEBUG | D3DCOMPILE_SKIP_OPTIMIZATION, // デバッグ用設定
+		0,
+		&vsBlob, &errorBlob);
+	if (FAILED(result)) {
+		// errorBlobからエラー内容をstring型にコピー
+		std::string errstr;
+		errstr.resize(errorBlob->GetBufferSize());
+
+		std::copy_n((char*)errorBlob->GetBufferPointer(),
+			errorBlob->GetBufferSize(),
+			errstr.begin());
+		errstr += "\n";
+		// エラー内容を出力ウィンドウに表示
+		OutputDebugStringA(errstr.c_str());
+		exit(1);
+	}
+
+	// ピクセルシェーダの読み込みとコンパイル
+	result = D3DCompileFromFile(
+		L"Resources/Shaders/ParticlePS.hlsl",	// シェーダファイル名
+		nullptr,
+		D3D_COMPILE_STANDARD_FILE_INCLUDE, // インクルード可能にする
+		"main", "ps_5_0",	// エントリーポイント名、シェーダーモデル指定
+		D3DCOMPILE_DEBUG | D3DCOMPILE_SKIP_OPTIMIZATION, // デバッグ用設定
+		0,
+		&psBlob, &errorBlob);
+	if (FAILED(result)) {
+		// errorBlobからエラー内容をstring型にコピー
+		std::string errstr;
+		errstr.resize(errorBlob->GetBufferSize());
+
+		std::copy_n((char*)errorBlob->GetBufferPointer(),
+			errorBlob->GetBufferSize(),
+			errstr.begin());
+		errstr += "\n";
+		// エラー内容を出力ウィンドウに表示
+		OutputDebugStringA(errstr.c_str());
+		exit(1);
+	}
+
+	// ジオメトリシェーダの読み込みとコンパイル
+	result = D3DCompileFromFile(
+		L"Resources/Shaders/ParticleGS.hlsl",	// シェーダファイル名
+		nullptr,
+		D3D_COMPILE_STANDARD_FILE_INCLUDE, // インクルード可能にする
+		"main", "gs_5_0",	// エントリーポイント名、シェーダーモデル指定
+		D3DCOMPILE_DEBUG | D3DCOMPILE_SKIP_OPTIMIZATION, // デバッグ用設定
+		0,
+		&gsBlob, &errorBlob);
+	if (FAILED(result)) {
+		// errorBlobからエラー内容をstring型にコピー
+		std::string errstr;
+		errstr.resize(errorBlob->GetBufferSize());
+
+		std::copy_n((char*)errorBlob->GetBufferPointer(),
+			errorBlob->GetBufferSize(),
+			errstr.begin());
+		errstr += "\n";
+		// エラー内容を出力ウィンドウに表示
+		OutputDebugStringA(errstr.c_str());
+		exit(1);
+	}
+
+#pragma endregion SHADER_COMPILE
+
+	// 頂点レイアウト
+	D3D12_INPUT_ELEMENT_DESC inputLayout[] = {
+		{ // xy座標(1行で書いたほうが見やすい)
+			"POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0,
+			D3D12_APPEND_ALIGNED_ELEMENT,
+			D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0
+		},
+		{ // スケール
+			"TEXCOORD", 0, DXGI_FORMAT_R32_FLOAT, 0,
+			D3D12_APPEND_ALIGNED_ELEMENT,
+			D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0
+		},
+		{
+			"COLOR", 0, DXGI_FORMAT_R32G32B32A32_FLOAT, 0,
+			D3D12_APPEND_ALIGNED_ELEMENT,
+			D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0
+		},
+		{
+			"WMATRIX",0, DXGI_FORMAT_R32G32B32A32_FLOAT, 0,
+			D3D12_APPEND_ALIGNED_ELEMENT,
+			D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0
+		},
+		{
+			"WMATRIX",1U, DXGI_FORMAT_R32G32B32A32_FLOAT, 0,
+			D3D12_APPEND_ALIGNED_ELEMENT,
+			D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0
+		},
+		{
+			"WMATRIX",2U, DXGI_FORMAT_R32G32B32A32_FLOAT, 0,
+			D3D12_APPEND_ALIGNED_ELEMENT,
+			D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0
+		},
+		{
+			"WMATRIX",3U, DXGI_FORMAT_R32G32B32A32_FLOAT, 0,
+			D3D12_APPEND_ALIGNED_ELEMENT,
+			D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0
+		},
+	};
+
+	// グラフィックスパイプラインの流れを設定
+	D3D12_GRAPHICS_PIPELINE_STATE_DESC gpipeline{};
+	gpipeline.VS = CD3DX12_SHADER_BYTECODE(vsBlob.Get());
+	gpipeline.PS = CD3DX12_SHADER_BYTECODE(psBlob.Get());
+	gpipeline.GS = CD3DX12_SHADER_BYTECODE(gsBlob.Get());
+
+	// サンプルマスク
+	gpipeline.SampleMask = D3D12_DEFAULT_SAMPLE_MASK; // 標準設定
+	// ラスタライザステート
+	gpipeline.RasterizerState = CD3DX12_RASTERIZER_DESC(D3D12_DEFAULT);
+	// デプスステンシルステート
+	gpipeline.DepthStencilState = CD3DX12_DEPTH_STENCIL_DESC(D3D12_DEFAULT);
+	// デプスの書き込みを禁止
+	gpipeline.DepthStencilState.DepthWriteMask = D3D12_DEPTH_WRITE_MASK_ZERO;
+
+	// レンダーターゲットのブレンド設定
+	D3D12_RENDER_TARGET_BLEND_DESC blenddesc{};
+	blenddesc.RenderTargetWriteMask = D3D12_COLOR_WRITE_ENABLE_ALL;	// RBGA全てのチャンネルを描画
+	blenddesc.BlendEnable = true;
+	// アルファブレンディング
+	//blenddesc.BlendOp = D3D12_BLEND_OP_ADD;//加算
+	//blenddesc.SrcBlend = D3D12_BLEND_SRC_ALPHA;//ソースの値を100%使用
+	//blenddesc.DestBlend = D3D12_BLEND_INV_SRC_ALPHA;//デストの値を100%使用
+	//// 減算ブレンディング
+	blenddesc.BlendOp = D3D12_BLEND_OP_ADD;
+	blenddesc.SrcBlend = D3D12_BLEND_ONE;
+	blenddesc.DestBlend = D3D12_BLEND_ONE;
+
+	blenddesc.BlendOpAlpha = D3D12_BLEND_OP_ADD;
+	blenddesc.SrcBlendAlpha = D3D12_BLEND_ONE;
+	blenddesc.DestBlendAlpha = D3D12_BLEND_ZERO;
+
+	// ブレンドステートの設定
+	gpipeline.BlendState.RenderTarget[0] = blenddesc;
+	//gpipeline.BlendState.RenderTarget[1] = blenddesc;
+	//gpipeline.BlendState.RenderTarget[2] = blenddesc;
+
+	// 深度バッファのフォーマット
+	gpipeline.DSVFormat = DXGI_FORMAT_D32_FLOAT;
+
+	// 頂点レイアウトの設定
+	gpipeline.InputLayout.pInputElementDescs = inputLayout;
+	gpipeline.InputLayout.NumElements = _countof(inputLayout);
+
+	// 図形の形状設定（点）
+	gpipeline.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_POINT;
+
+	gpipeline.NumRenderTargets = 1;	// 描画対象は3つディファー土に合わせる
+	gpipeline.RTVFormats[0] = DXGI_FORMAT_R8G8B8A8_UNORM; // 0～255指定のRGBA
+	//gpipeline.RTVFormats[1] = DXGI_FORMAT_R8G8B8A8_UNORM; // 0～255指定のRGBA
+	//gpipeline.RTVFormats[2] = DXGI_FORMAT_R8G8B8A8_UNORM; // 0～255指定のRGBA
+	gpipeline.SampleDesc.Count = 1; // 1ピクセルにつき1回サンプリング
+
+	// デスクリプタレンジ
+	CD3DX12_DESCRIPTOR_RANGE descRangeSRV;
+	descRangeSRV.Init(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, 1, 0); // t0 レジスタ
+
+	// ルートパラメータ
+	CD3DX12_ROOT_PARAMETER rootparams[2];
+	rootparams[0].InitAsConstantBufferView(0, 0, D3D12_SHADER_VISIBILITY_ALL);
+	rootparams[1].InitAsDescriptorTable(1, &descRangeSRV, D3D12_SHADER_VISIBILITY_ALL);
+
+	// スタティックサンプラー
+	CD3DX12_STATIC_SAMPLER_DESC samplerDesc = CD3DX12_STATIC_SAMPLER_DESC(0);
+
+	// ルートシグネチャの設定
+	CD3DX12_VERSIONED_ROOT_SIGNATURE_DESC rootSignatureDesc;
+	rootSignatureDesc.Init_1_0(_countof(rootparams), rootparams, 1, &samplerDesc, D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT);
+
+	ComPtr<ID3DBlob> rootSigBlob;
+	// バージョン自動判定のシリアライズ
+	result = D3DX12SerializeVersionedRootSignature(&rootSignatureDesc, D3D_ROOT_SIGNATURE_VERSION_1_0, &rootSigBlob, &errorBlob);
+	// ルートシグネチャの生成
+	result = RAKI_DX12B_DEV->CreateRootSignature(0, rootSigBlob->GetBufferPointer(), rootSigBlob->GetBufferSize(), IID_PPV_ARGS(&rootsig));
+	if (FAILED(result)) {
+		assert(0);
+	}
+
+	gpipeline.pRootSignature = rootsig.Get();
+
+	// グラフィックスパイプラインの生成
+	result = Raki_DX12B::Get()->GetDevice()->CreateGraphicsPipelineState(&gpipeline, IID_PPV_ARGS(&pipeline3D));
+
+	if (FAILED(result)) {
+		assert(0);
+	}
+
+}
+
+void ParticleDrawManager::SetCommonBeginDrawParticle3D()
+{
+	
+
+	RAKI_DX12B_CMD->SetPipelineState(pipeline3D.Get());
+}
+
+void ParticleDrawManager::SetCommonBeginDrawParticle2D()
+{
+	RAKI_DX12B_CMD->SetPipelineState(pipeline2D.Get());
 }

--- a/RakiEngine_Library/ParticleManager.h
+++ b/RakiEngine_Library/ParticleManager.h
@@ -114,6 +114,31 @@ public:
 	//描画、終了は必要ない（実際の描画はエミッターでやるので）
 };
 
+class ParticleDrawManager 
+{
+public:
+
+	ParticleDrawManager() = default;
+	~ParticleDrawManager() = default;
+
+	void Init();
+
+	void SetCommonBeginDrawParticle3D();
+
+	void SetCommonBeginDrawParticle2D();
+
+private:
+	// Microsoft::WRL::を省略
+	template <class T> using ComPtr = Microsoft::WRL::ComPtr<T>;
+
+	// ルートシグネチャ
+	ComPtr<ID3D12RootSignature> rootsig;
+	// グラフィックスパイプライン
+	ComPtr<ID3D12PipelineState> pipeline2D;
+	ComPtr<ID3D12PipelineState> pipeline3D;
+
+};
+
 class ParticleManager
 {
 private:

--- a/RakiEngine_Library/RakiEngine_Library.vcxproj
+++ b/RakiEngine_Library/RakiEngine_Library.vcxproj
@@ -55,6 +55,7 @@
     <ClCompile Include="FontDrawer.cpp" />
     <ClCompile Include="FPS.cpp" />
     <ClCompile Include="GameObject.cpp" />
+    <ClCompile Include="GraphicManager.cpp" />
     <ClCompile Include="imgui\imgui.cpp" />
     <ClCompile Include="imgui\imgui_demo.cpp" />
     <ClCompile Include="imgui\imgui_draw.cpp" />
@@ -113,6 +114,7 @@
     <ClInclude Include="FontDrawer.h" />
     <ClInclude Include="FPS.h" />
     <ClInclude Include="GameObject.h" />
+    <ClInclude Include="GraphicManager.h" />
     <ClInclude Include="imgui\imconfig.h" />
     <ClInclude Include="imgui\imgui.h" />
     <ClInclude Include="imgui\imgui_impl_dx12.h" />

--- a/RakiEngine_Library/RakiEngine_Library.vcxproj.filters
+++ b/RakiEngine_Library/RakiEngine_Library.vcxproj.filters
@@ -255,6 +255,9 @@
     <ClCompile Include="RakiUtility.cpp">
       <Filter>ソース ファイル</Filter>
     </ClCompile>
+    <ClCompile Include="GraphicManager.cpp">
+      <Filter>Graphic</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Raki_imguiMgr.h">
@@ -436,6 +439,9 @@
     </ClInclude>
     <ClInclude Include="RakiUtility.h">
       <Filter>utility</Filter>
+    </ClInclude>
+    <ClInclude Include="GraphicManager.h">
+      <Filter>Graphic</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/RakiEngine_Library/RakiUtility.cpp
+++ b/RakiEngine_Library/RakiUtility.cpp
@@ -1,4 +1,5 @@
 #include "RakiUtility.h"
+#include "NY_random.h"
 
 int rutility::GetDigits(float value, int left, int right)
 {
@@ -13,6 +14,45 @@ int rutility::GetDigits(float value, int left, int right)
 
     /* mŒ…–ÚˆÈã‚ÌŒ…‚ðŽæ“¾ */
     result = int(mod_value / pow(10, left));
+
+    return result;
+}
+
+RVector3 rutility::randomRV3(RVector3 pos1, RVector3 pos2)
+{
+    RVector3 vmax;
+    RVector3 vmin;
+    
+    if (pos1.x > pos2.x) {
+        vmax.x = pos1.x;
+        vmin.x = pos2.x;
+    }
+    else {
+        vmax.x = pos2.x;
+        vmin.x = pos1.x;
+    }
+    if (pos1.y > pos2.y) {
+        vmax.y = pos1.y;
+        vmin.y = pos2.y;
+    }
+    else {
+        vmax.y = pos2.y;
+        vmin.y = pos1.y;
+    }
+    if (pos1.z > pos2.z) {
+        vmax.z = pos1.z;
+        vmin.z = pos2.z;
+    }
+    else {
+        vmax.z = pos2.z;
+        vmin.z = pos1.z;
+    }
+
+    RVector3 result;
+
+    result.x = NY_random::floatrand_sl(vmax.x, vmin.x);
+    result.y = NY_random::floatrand_sl(vmax.y, vmin.y);
+    result.z = NY_random::floatrand_sl(vmax.z, vmin.z);
 
     return result;
 }

--- a/RakiEngine_Library/RakiUtility.h
+++ b/RakiEngine_Library/RakiUtility.h
@@ -3,6 +3,8 @@
 #include <cstdlib>
 #include <math.h>
 
+#include "RVector.h"
+
 //Šù‘¶‚ÌŠÖ”‚Æ‚©‚Ô‚ç‚È‚¢‚æ‚¤‚É
 //í—Ş‚ª‘‚¦‚½‚ç‚±‚Ì’†‚©‚ç‚³‚ç‚É–¼‘O‹óŠÔ•ª‚¯‚·‚é
 namespace rutility
@@ -14,6 +16,8 @@ namespace rutility
 
 
 
+
+	RVector3 randomRV3(RVector3 pos1, RVector3 pos2);
 
 }
 

--- a/RakiEngine_Library/Raki_DX12B.cpp
+++ b/RakiEngine_Library/Raki_DX12B.cpp
@@ -515,12 +515,7 @@ bool Raki_DX12B::CreateFence()
 Raki_DX12B::~Raki_DX12B()
 {
 #ifdef _DEBUG
-	ID3D12DebugDevice* debugDevice;
-	if (SUCCEEDED(device.Get()->QueryInterface(&debugDevice)))
-	{
-		debugDevice->ReportLiveDeviceObjects(D3D12_RLDO_DETAIL | D3D12_RLDO_IGNORE_INTERNAL);
-		debugDevice->Release();
-	}
+
 
 #endif
 }
@@ -570,6 +565,7 @@ void Raki_DX12B::Initialize(Raki_WinAPI *win, bool isStopifFatalErrorDetected)
 			infoqueue->SetBreakOnSeverity(D3D12_MESSAGE_SEVERITY_ERROR, true);
 			infoqueue->SetBreakOnSeverity(D3D12_MESSAGE_SEVERITY_WARNING, true);
 		}
+		infoqueue->Release();
 	}
 
 #endif // _DEBUG
@@ -710,6 +706,41 @@ void Raki_DX12B::ClearDepthBuffer()
 	CD3DX12_CPU_DESCRIPTOR_HANDLE dsvH = CD3DX12_CPU_DESCRIPTOR_HANDLE(dsvHeap->GetCPUDescriptorHandleForHeapStart());
 	// 深度バッファのクリア
 	commandList->ClearDepthStencilView(dsvH, D3D12_CLEAR_FLAG_DEPTH, 1.0f, 0, 0, nullptr);
+}
+
+void Raki_DX12B::Destroy()
+{
+	ID3D12Device* dev = *device.ReleaseAndGetAddressOf();
+	ID3D12CommandAllocator* cmdalloc = *commandAllocator.ReleaseAndGetAddressOf();
+	ID3D12GraphicsCommandList* cmdlist = *commandList.ReleaseAndGetAddressOf();
+	ID3D12CommandQueue* cmdqueue = *commandQueue.ReleaseAndGetAddressOf();
+	ID3D12Fence* f = *fence.ReleaseAndGetAddressOf();
+
+	dev->Release();
+
+	delete dev;
+	delete cmdalloc;
+	delete cmdlist;
+	delete cmdqueue;
+	delete f;
+	dev = nullptr;
+	cmdalloc = nullptr;
+	cmdlist = nullptr;
+	cmdqueue = nullptr;
+	f = nullptr;
+}
+
+void Raki_DX12B::Finalize()
+{
+#ifdef _DEBUG
+	ID3D12DebugDevice* debugDevice;
+	device.Get()->QueryInterface(&debugDevice);
+#endif
+	Destroy();
+#ifdef _DEBUG
+	debugDevice->ReportLiveDeviceObjects(D3D12_RLDO_DETAIL | D3D12_RLDO_IGNORE_INTERNAL);
+	debugDevice->Release();
+#endif
 }
 
 bool Raki_DX12B::InitInput(Raki_WinAPI *win)

--- a/RakiEngine_Library/Raki_DX12B.cpp
+++ b/RakiEngine_Library/Raki_DX12B.cpp
@@ -716,8 +716,6 @@ void Raki_DX12B::Destroy()
 	ID3D12CommandQueue* cmdqueue = *commandQueue.ReleaseAndGetAddressOf();
 	ID3D12Fence* f = *fence.ReleaseAndGetAddressOf();
 
-	dev->Release();
-
 	delete dev;
 	delete cmdalloc;
 	delete cmdlist;

--- a/RakiEngine_Library/Raki_DX12B.h
+++ b/RakiEngine_Library/Raki_DX12B.h
@@ -133,6 +133,11 @@ public:
 		fence.ReleaseAndGetAddressOf();
 	}
 
+	void Destroy();
+
+	//手動解放、リーク検知
+	void Finalize();
+
 private:
 	//DirectX12要素のメンバ変数
 

--- a/RakiEngine_Library/SpriteManager.cpp
+++ b/RakiEngine_Library/SpriteManager.cpp
@@ -354,3 +354,11 @@ void SpriteManager::SetCommonBeginDrawRTex(int handle)
     ID3D12DescriptorHeap* ppHeaps[] = { RenderTargetManager::GetInstance()->renderTextures[handle]->GetDescriptorHeapSRV() };
     cmd->SetDescriptorHeaps(_countof(ppHeaps), ppHeaps);
 }
+
+SpriteData::~SpriteData()
+{
+    insWorldMatrixes.clear();
+    insWorldMatrixes.shrink_to_fit();
+
+    TexManager::DeleteTexture(texNumber);
+}

--- a/RakiEngine_Library/SpriteManager.h
+++ b/RakiEngine_Library/SpriteManager.h
@@ -74,10 +74,7 @@ typedef struct SpriteData
 	{
 
 	}
-	~SpriteData(){
-		insWorldMatrixes.clear();
-		insWorldMatrixes.shrink_to_fit();
-	}
+	~SpriteData();
 
 }SPData;
 

--- a/RakiEngine_Library/TexManager.cpp
+++ b/RakiEngine_Library/TexManager.cpp
@@ -207,6 +207,21 @@ UINT TexManager::LoadDivTextureTest(uvAnimData *data,const char *filename, const
     return useNo;
 }
 
+void TexManager::DeleteTexture(UINT texhandle)
+{
+    //範囲外参照防止
+    if (texhandle < 0 || texhandle > 2047) {
+        return;
+    }
+
+    if (textureData[texhandle].texBuff.Get()) {
+        ID3D12Resource* res = *textureData[texhandle].texBuff.ReleaseAndGetAddressOf();
+
+        delete res;
+        res = nullptr;
+    }
+}
+
 void uvAnimData::AddOffsets(UVOFFSETS offset)
 {
     //オフセット格納

--- a/RakiEngine_Library/TexManager.h
+++ b/RakiEngine_Library/TexManager.h
@@ -96,6 +96,6 @@ public:
 	/// <returns>格納したテクスチャの場所を配列で</returns>
 	static UINT LoadDivTextureTest(uvAnimData *data, const char *filename, const int numDivTex, int sizeX);
 
-
+	static void DeleteTexture(UINT texhandle);
 };
 

--- a/TD4_Game/BaseScene.h
+++ b/TD4_Game/BaseScene.h
@@ -29,6 +29,6 @@ public:
     virtual void Draw() override{}            //描画処理をオーバーライド。
     virtual void Draw2D() override{}
     virtual void DrawImgui() override{}
-
+    virtual void DrawParticle() {}
 };
 

--- a/TD4_Game/EngineDebugScene.cpp
+++ b/TD4_Game/EngineDebugScene.cpp
@@ -5,6 +5,8 @@
 
 #include <FbxLoader.h>
 
+#include <RakiUtility.h>
+
 using namespace Rv3Ease;
 
 EngineDebugScene::EngineDebugScene(ISceneChanger* changer)
@@ -56,6 +58,19 @@ EngineDebugScene::EngineDebugScene(ISceneChanger* changer)
 	q1 *= q2;
 
 	lightdir = RVector3(0, 0, 1);
+
+	testp = std::make_unique<ParticleManager>();
+	testp.reset(ParticleManager::Create());
+	particleTex = TexManager::LoadTexture("Resources/effect1.png");
+	pgstate.scale_end = 0.0f;
+	pgstate.scale_start = 2.0f;
+	pgstate.position = RVector3(0, 50, 0);
+	pgstate.isRandomSpawn = true;
+	pgstate.position_spawnRange1 = RVector3(50.f, 50.f, 50.f);
+	pgstate.position_spawnRange1 = RVector3(-50.f, -50.f, -50.f);
+	pgstate.aliveTime = 60;
+	pgstate.color_start = { 1.f,1.f,1.f,1.f };
+	pgstate.color_end = { 1.f,1.f,1.f,0.f };
 }
 
 EngineDebugScene::~EngineDebugScene()
@@ -79,6 +94,11 @@ void EngineDebugScene::Update()
 	testobject->SetAffineParamTranslate(testEase.Update());
 
 	if (Input::isKeyTrigger(DIK_O)) { Audio::PlayLoadedSound(testSE, true); }
+
+	if (Input::isKey(DIK_G)) { 
+		pgstate.vel = rutility::randomRV3(RVector3(1, 1, 1), RVector3(-1, -1, -1));
+		testp->Add(pgstate);
+	}
 }
 
 void EngineDebugScene::Draw()
@@ -171,4 +191,10 @@ void EngineDebugScene::DrawImgui()
 	testobj->SetAffineParamRotate(RVector3(rotX, rotY, rotZ));
 	testobject->SetAffineParamRotate(RVector3(rotX, rotY, rotZ));
 
+}
+
+void EngineDebugScene::DrawParticle()
+{
+	testp->Update();
+	testp->Draw(particleTex);
 }

--- a/TD4_Game/EngineDebugScene.cpp
+++ b/TD4_Game/EngineDebugScene.cpp
@@ -99,8 +99,13 @@ void EngineDebugScene::Draw2D()
 
 	testNum.DrawSprite(0, 100);
 
-	testNum.DrawNumSpriteZeroFill(0, 0, 32, 32, dval, 10);
+	testNum.DrawNumSprite(0, 0, 32, 32, dval);
 	testNum.uvOffsetHandle = 1;
+
+	if(dval <20000000){
+		dval += 1;
+	}
+
 
 	testNum.Draw();
 }

--- a/TD4_Game/EngineDebugScene.h
+++ b/TD4_Game/EngineDebugScene.h
@@ -4,7 +4,7 @@
 #include <NY_Object3DMgr.h>
 #include <Sprite.h>
 #include <Raki_Input.h>
-
+#include <ParticleManager.h>
 #include <CameraCalc.h>
 #include <Audio.h>
 
@@ -21,6 +21,7 @@ public:
     void Draw() override;            //描画処理をオーバーライド。
     void Draw2D() override;
     void DrawImgui() override;
+    void DrawParticle() override;
 
     Sprite testsp1;
     Sprite testsp2;
@@ -53,5 +54,10 @@ public:
 
     Sprite testNum;
     int dval = 0;
+
+    //パーティクル
+    std::unique_ptr<ParticleManager> testp;
+    UINT particleTex;
+    ParticleGrainState pgstate;
 };
 

--- a/TD4_Game/Resources/effect1.png
+++ b/TD4_Game/Resources/effect1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0e8ab6d70ac9991e41572f64b24e439348a933fee2ad000229970db85a3c089d
+size 21151

--- a/TD4_Game/SceneManager.cpp
+++ b/TD4_Game/SceneManager.cpp
@@ -80,6 +80,11 @@ void SceneManager::DrawImgui()
     nowScene->DrawImgui();
 }
 
+void SceneManager::DrawParticle()
+{
+    nowScene->DrawParticle();
+}
+
 void SceneManager::ChangeScene(eScene NextScene)
 {
     //次のシーン番号をセット

--- a/TD4_Game/SceneManager.h
+++ b/TD4_Game/SceneManager.h
@@ -29,6 +29,8 @@ public:
     void Draw2D() override;
     void DrawImgui() override;
 
+    void DrawParticle();
+
     // ˆø” nextScene ‚ÉƒV[ƒ“‚ğ•ÏX‚·‚é
     void ChangeScene(eScene NextScene) override;
 

--- a/TD4_Game/imgui.ini
+++ b/TD4_Game/imgui.ini
@@ -9,7 +9,7 @@ Size=351,263
 Collapsed=0
 
 [Window][light ctrl]
-Pos=569,140
+Pos=111,203
 Size=285,155
 Collapsed=0
 

--- a/TD4_Game/imgui.ini
+++ b/TD4_Game/imgui.ini
@@ -14,7 +14,7 @@ Size=285,155
 Collapsed=0
 
 [Window][Audio Control]
-Pos=1075,378
+Pos=1002,344
 Size=150,300
 Collapsed=0
 

--- a/TD4_Game/main.cpp
+++ b/TD4_Game/main.cpp
@@ -77,10 +77,14 @@ int WINAPI WinMain(HINSTANCE, HINSTANCE, LPSTR, int)
 		sceneMgr->Draw();
 
 		FieldDrawer::get()->Draw();
+
 		//3D通常描画ここまで
 		graphicmgr.EndDefferdDraw();
+
 		//パーティクル3Dここから
 		graphicmgr.StartParticleDraw3D();
+
+		sceneMgr->DrawParticle();
 
 		//スプライトここから
 		graphicmgr.StartSpriteDraw();
@@ -95,9 +99,6 @@ int WINAPI WinMain(HINSTANCE, HINSTANCE, LPSTR, int)
 
 		FPS::Get()->run();
 	}
-
-
-
 	
 	myImgui::FinalizeImGui();
 


### PR DESCRIPTION
# Engine更新

## 描画順を固定する処理を追加

エンジンに描画順管理用ラッパークラス、GraphicManagerを追加しました。
それに合わせてmain.cppを変更しました。
正しい描画順は以下の通りです。
object3d -> particle -> sprite

## Particle描画用の関数追加
上記の変更により、描画順が違うドローコールはエラーとなりました。
そのため、パーティクル用の描画関数を追加しました。

基底クラスBaseSceneに仮想関数を追加しました。
void ParticleDraw() です。

パーティクルのDraw()はここに記述してください。（ほかはそのままでもOK）

## パーティクル修正

- ParticleGrainStateを用いたパーティクル生成時、ランダム生成オプションが機能していない問題を修正

## Utility追加

```
RVector3 rutility::randomRV3(RVector3 pos1, RVector3 pos2)
```
RVector3で乱数を生成できる関数を追加しました。
pos1 から pos2の範囲で乱数を生成できます。

パーティクルで便利かもしれません。
