### PR TITLE
Engine

### DIFF
--- a/RakiEngine_Library/Audio.cpp
+++ b/RakiEngine_Library/Audio.cpp
@@ -1,4 +1,6 @@
 ﻿#include "Audio.h"
+#include "RakiUtility.h"
+#include "Raki_DX12B.h"
 
 #include <algorithm>
 
@@ -14,9 +16,13 @@ void Audio::Init()
     result = xAudio2->CreateMasteringVoice(&masterVoice);
     //ボリューム初期化(50%)
     mastervolume = 0.5f;
+
+    // MediaFoundation初期化
+    result = CoInitializeEx(nullptr, COINIT_MULTITHREADED);
+    result = MFStartup(MF_VERSION, MFSTARTUP_NOSOCKET);
 }
 
-SoundData Audio::LoadSound_wav(const char *filename, SoundData *ptr)
+SoundData Audio::LoadSound_wav(const char *filename)
 {
     //ファイル入力ストリームのインスタンス
     std::ifstream file;
@@ -24,6 +30,10 @@ SoundData Audio::LoadSound_wav(const char *filename, SoundData *ptr)
     file.open(filename, std::ios_base::binary);
     //オープン失敗を検出
     assert(file.is_open());
+
+    //返却するデータ
+    SoundData* soundData = new SoundData();
+    HRESULT result;
 
     //RIFTヘッダー読み込み
     RiffHeader riff;
@@ -48,12 +58,32 @@ SoundData Audio::LoadSound_wav(const char *filename, SoundData *ptr)
         //再読み込み
         file.read((char *)&format, sizeof(ChunkHeader));
     }
-    if (strncmp(format.chunk.id, "fmt ", 4) != 0) {
-        assert(0);
+    //LISTチャンク検出時
+    if (strncmp(format.chunk.id, "LIST", 4) == 0) {
+        //読み取りをジャンクチャンクの終わりまで進める
+        file.seekg(format.chunk.size, std::ios_base::cur);
+        //再読み込み
+        file.read((char*)&format, sizeof(ChunkHeader));
     }
-    //チャンク本体の読み込み
-    assert(format.chunk.size <= sizeof(format.fmt));
-    file.read((char *)&format.fmt, format.chunk.size);
+    //フォーマットチャンク検出時
+    if (strncmp(format.chunk.id, "fmt ", 4) == 0) {
+        //チャンク本体の読み込み
+        assert(format.chunk.size <= sizeof(format.fmt));
+        //先頭4バイトからデータ型を特定
+        if (format.chunk.size == int32_t(18)) {
+            soundData->byteMode = FMT_BYTE_18;
+            file.read((char*)&format.fmt, format.chunk.size);
+        }
+        else if (format.chunk.size == int32_t(16)) {
+            soundData->byteMode = FMT_BYTE_16;
+            file.read((char*)&format.pcmwf, format.chunk.size);
+        }
+        else if (format.chunk.size == int32_t(40)) {
+            soundData->byteMode = FMT_BYTE_40;
+            file.read((char*)&format.wften, format.chunk.size);
+        }
+
+    }
 
     //Dataチャンクの読み込み
     ChunkHeader data;
@@ -65,6 +95,13 @@ SoundData Audio::LoadSound_wav(const char *filename, SoundData *ptr)
         //再読み込み
         file.read((char *)&data, sizeof(data));
     }
+    //LISTチャンク検出時
+    if (strncmp(data.id, "LIST", 4) == 0) {
+        //読み取りをジャンクチャンクの終わりまで進める
+        file.seekg(data.size, std::ios_base::cur);
+        //再読み込み
+        file.read((char*)&data, sizeof(data));
+    }
     if (strncmp(data.id, "data", 4) != 0) {
         assert(0);
     }
@@ -74,14 +111,40 @@ SoundData Audio::LoadSound_wav(const char *filename, SoundData *ptr)
     //wavを閉じる
     file.close();
 
-    //返却するデータ
-    SoundData *soundData = new SoundData();
-    soundData->wfex       = format.fmt;
+    switch (soundData->byteMode)
+    {
+    case FMT_BYTE_16:
+        //WAVEFORMATEXに合わせる
+        soundData->wfex.wFormatTag = format.pcmwf.wf.wFormatTag;
+        soundData->wfex.nChannels = format.pcmwf.wf.nChannels;
+        soundData->wfex.nSamplesPerSec = format.pcmwf.wf.nSamplesPerSec;
+        soundData->wfex.nBlockAlign = format.pcmwf.wf.nBlockAlign;
+        soundData->wfex.nAvgBytesPerSec = format.pcmwf.wf.nAvgBytesPerSec;
+        soundData->wfex.wBitsPerSample = format.pcmwf.wBitsPerSample;
+        //波形フォーマットをもとにソースの作成
+        result = xAudio2->CreateSourceVoice(&soundData->source, &soundData->wfex);
+        ExportHRESULTmessage(result);
+        break;
+    case FMT_BYTE_18:
+        soundData->wfex = format.fmt;
+        //波形フォーマットをもとにソースの作成
+        result = xAudio2->CreateSourceVoice(&soundData->source, &soundData->wfex);
+        break;
+    case FMT_BYTE_40:
+        //WAVEFORMATEXに合わせる
+        soundData->wfex = format.wften.Format;
+        //波形フォーマットをもとにソースの作成
+        result = xAudio2->CreateSourceVoice(&soundData->source, &soundData->wfex);
+        break;
+    default:
+        break;
+    }
+
+
     soundData->pBuffer    = reinterpret_cast<BYTE*>(pBuffer);
     soundData->bufferSize = data.size;
-    HRESULT result;
-    //波形フォーマットをもとにソースの作成
-    result = xAudio2->CreateSourceVoice(&soundData->source, &soundData->wfex);
+
+
     assert(SUCCEEDED(result));
 
     //再生する波形データの設定
@@ -89,9 +152,72 @@ SoundData Audio::LoadSound_wav(const char *filename, SoundData *ptr)
     soundData->buf.AudioBytes = soundData->bufferSize;
     soundData->buf.Flags = XAUDIO2_END_OF_STREAM;
 
-    ptr = soundData;
-
     return *soundData;
+}
+
+SoundData Audio::LoadSound_mp3(const char* filename)
+{
+    HRESULT result;
+
+    IMFSourceReader* pMFSourceReader{ nullptr };
+
+    std::wstring path = rutility::charTowstring(filename);
+
+    result = MFCreateSourceReaderFromURL(path.c_str(), NULL, &pMFSourceReader);
+    ExportHRESULTmessage(result);
+    
+
+    IMFMediaType* pMFMediaType{ nullptr };
+    MFCreateMediaType(&pMFMediaType);
+    pMFMediaType->SetGUID(MF_MT_MAJOR_TYPE, MFMediaType_Audio);
+    pMFMediaType->SetGUID(MF_MT_SUBTYPE, MFAudioFormat_PCM);
+    pMFSourceReader->SetCurrentMediaType(MF_SOURCE_READER_FIRST_AUDIO_STREAM, nullptr, pMFMediaType);
+
+    pMFMediaType->Release();
+    pMFMediaType = nullptr;
+    pMFSourceReader->GetCurrentMediaType(MF_SOURCE_READER_FIRST_AUDIO_STREAM, &pMFMediaType);
+
+    SoundData sounddata;
+    //MFCreateWaveFormatExFromMFMediaType(pMFMediaType, &sounddata.wfex, nullptr);
+
+    std::vector<BYTE> mediaData;
+    while (true)
+    {
+        IMFSample* pMFSample{ nullptr };
+        DWORD dwStreamFlags{ 0 };
+        pMFSourceReader->ReadSample(MF_SOURCE_READER_FIRST_AUDIO_STREAM, 0, nullptr, &dwStreamFlags, nullptr, &pMFSample);
+
+        if (dwStreamFlags & MF_SOURCE_READERF_ENDOFSTREAM)
+        {
+            break;
+        }
+
+        IMFMediaBuffer* pMFMediaBuffer{ nullptr };
+        pMFSample->ConvertToContiguousBuffer(&pMFMediaBuffer);
+
+        BYTE* pBuffer{ nullptr };
+        DWORD cbCurrentLength{ 0 };
+        pMFMediaBuffer->Lock(&pBuffer, nullptr, &cbCurrentLength);
+
+        mediaData.resize(mediaData.size() + cbCurrentLength);
+        memcpy(mediaData.data() + mediaData.size() - cbCurrentLength, pBuffer, cbCurrentLength);
+
+        pMFMediaBuffer->Unlock();
+
+        pMFMediaBuffer->Release();
+        pMFSample->Release();
+    }
+
+    //ソースに格納
+    //xAudio2->CreateSourceVoice(&sounddata.source, sounddata.wfex);
+    assert(SUCCEEDED(result));
+    sounddata.pBuffer = reinterpret_cast<BYTE*>(mediaData.data());
+    //バッファに格納
+    sounddata.buf.pAudioData = mediaData.data();
+    sounddata.buf.Flags = XAUDIO2_END_OF_STREAM;
+    sounddata.buf.AudioBytes = sizeof(BYTE) * static_cast<UINT32>(mediaData.size());
+
+    return sounddata;
 }
 
 void Audio::UnloadSound(SoundData *data)

--- a/RakiEngine_Library/Audio.cpp
+++ b/RakiEngine_Library/Audio.cpp
@@ -133,6 +133,7 @@ SoundData Audio::LoadSound_wav(const char *filename)
     case FMT_BYTE_40:
         //WAVEFORMATEXに合わせる
         soundData->wfex = format.wften.Format;
+        soundData->wfex.wFormatTag = WORD(1);
         //波形フォーマットをもとにソースの作成
         result = xAudio2->CreateSourceVoice(&soundData->source, &soundData->wfex);
         break;

--- a/RakiEngine_Library/Audio.h
+++ b/RakiEngine_Library/Audio.h
@@ -4,8 +4,17 @@
 #include <fstream>
 #include <assert.h>
 #include <wrl.h>
+#include <mfapi.h>
+#include <mfidl.h>
+#include <mfreadwrite.h>
 
+// mediafoundation
+#pragma comment(lib, "Mf.lib")
+#pragma comment(lib, "mfplat.lib")
+#pragma comment(lib, "Mfreadwrite.lib")
+#pragma comment(lib, "mfuuid.lib")
 
+// xaudio
 #pragma comment(lib,"xaudio2.lib")
 
 using namespace Microsoft::WRL;
@@ -24,14 +33,29 @@ struct RiffHeader {
 
 //FMTチャンク
 struct FormatChunk {
-	ChunkHeader  chunk; //"fmt "
-	WAVEFORMATEX fmt;   //波形フォーマット
+	ChunkHeader				chunk; //"fmt "
+	WAVEFORMAT				wf;
+	PCMWAVEFORMAT			pcmwf;
+	WAVEFORMATEX			fmt;   //波形フォーマット
+	WAVEFORMATEXTENSIBLE	wften;
+};
+
+enum FMT_BYTE {
+	FMT_BYTE_16,
+	FMT_BYTE_18,
+	FMT_BYTE_40,
 };
 
 //音声データ
 struct SoundData {
-	//波形フォーマット
-	WAVEFORMATEX wfex;
+	//波形フォーマット（大きさに応じてデータ型が異なる、なんでだよ）
+	WAVEFORMAT				wf;
+	PCMWAVEFORMAT			pcmwf;
+	WAVEFORMATEX			wfex;
+	WAVEFORMATEXTENSIBLE	wften;
+
+	FMT_BYTE byteMode;
+
 	//バッファ先頭アドレス
 	BYTE *pBuffer = nullptr;
 	//バッファサイズ
@@ -50,10 +74,12 @@ struct SoundData {
 class Audio
 {
 private:
-
+	// XAudio
 	static ComPtr<IXAudio2>        xAudio2;
 	static IXAudio2MasteringVoice *masterVoice;
 	static float mastervolume;
+
+	static SoundData LoadSound_mp3(const char* filename);
 
 public:
 
@@ -70,7 +96,9 @@ public:
 	static void Init();
 
 	//サウンドデータの読み込み
-	static SoundData LoadSound_wav(const char* filename, SoundData* ptr = nullptr);
+	static SoundData LoadSound_wav(const char* filename);
+
+
 	//サウンドデータのアンロード
 	static void UnloadSound(SoundData *data);
 	

--- a/RakiEngine_Library/RakiEngine_Library.vcxproj.filters
+++ b/RakiEngine_Library/RakiEngine_Library.vcxproj.filters
@@ -252,11 +252,11 @@
     <ClCompile Include="DebugCamera.cpp">
       <Filter>Camera</Filter>
     </ClCompile>
-    <ClCompile Include="RakiUtility.cpp">
-      <Filter>ソース ファイル</Filter>
-    </ClCompile>
     <ClCompile Include="GraphicManager.cpp">
       <Filter>Graphic</Filter>
+    </ClCompile>
+    <ClCompile Include="RakiUtility.cpp">
+      <Filter>utility</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/TD4_Game/EngineDebugScene.cpp
+++ b/TD4_Game/EngineDebugScene.cpp
@@ -44,7 +44,7 @@ EngineDebugScene::EngineDebugScene(ISceneChanger* changer)
 
 	//âπÉçÅ[Éh
 	testSE = Audio::LoadSound_wav("Resources/don.wav");
-	testBGM = Audio::LoadSound_wav("Resources/sounds/bgm/resultbgm.wav");
+	testBGM = Audio::LoadSound_wav("Resources/sounds/bgm/titlebgm.wav");
 
 	testNum.CreateAndSetDivisionUVOffsets(10, 10, 1, 64, 64, TexManager::LoadTexture("Resources/Score.png"));
 

--- a/TD4_Game/EngineDebugScene.cpp
+++ b/TD4_Game/EngineDebugScene.cpp
@@ -44,7 +44,7 @@ EngineDebugScene::EngineDebugScene(ISceneChanger* changer)
 
 	//âπÉçÅ[Éh
 	testSE = Audio::LoadSound_wav("Resources/don.wav");
-	testBGM = Audio::LoadSound_wav("Resources/kari.wav");
+	testBGM = Audio::LoadSound_wav("Resources/sounds/bgm/resultbgm.wav");
 
 	testNum.CreateAndSetDivisionUVOffsets(10, 10, 1, 64, 64, TexManager::LoadTexture("Resources/Score.png"));
 

--- a/TD4_Game/GameSoundMgr.cpp
+++ b/TD4_Game/GameSoundMgr.cpp
@@ -14,22 +14,22 @@ void GameSoundMgr::Init()
 
 
 	std::string ext = ".wav";
-	for (int i = 0; i < 3; i++) {
-		std::string slapfilename = "slap";
-		std::string cutfilename = "cut";
-		std::string num = std::to_string(i + 1);
+	//for (int i = 0; i < 3; i++) {
+	//	std::string slapfilename = "slap";
+	//	std::string cutfilename = "cut";
+	//	std::string num = std::to_string(i + 1);
 
-		std::string cutfilepass = pass + sefolder + cutfilename + num + ext;
-		std::string slapfilepass = pass + sefolder + cutfilename + num + ext;
+	//	std::string cutfilepass = pass + sefolder + cutfilename + num + ext;
+	//	std::string slapfilepass = pass + sefolder + cutfilename + num + ext;
 
-		if (i < 2) {
-			cutSe[i] = Audio::LoadSound_wav(cutfilepass.c_str());
-		}
-		slapSe[i] = Audio::LoadSound_wav(slapfilepass.c_str());
-	}
-	pullSe = Audio::LoadSound_wav("Resources/sounds/se/pull.wav");
-	Audio::LoadSound_wav("Resources/sounds/se/ok.wav", &buttonSe);
-	cancelSe = Audio::LoadSound_wav("Resources/sounds/se/cancel.wav");
+	//	if (i < 2) {
+	//		cutSe[i] = Audio::LoadSound_wav(cutfilepass.c_str());
+	//	}
+	//	slapSe[i] = Audio::LoadSound_wav(slapfilepass.c_str());
+	//}
+	//pullSe = Audio::LoadSound_wav("Resources/sounds/se/pull.wav");
+	//Audio::LoadSound_wav("Resources/sounds/se/ok.wav", &buttonSe);
+	//cancelSe = Audio::LoadSound_wav("Resources/sounds/se/cancel.wav");
 
 	titleBgm = Audio::LoadSound_wav("Resources/sounds/bgm/titlebgm.wav");
 	gameBgm = Audio::LoadSound_wav("Resources/sounds/bgm/gamebgm.wav");

--- a/TD4_Game/GameSoundMgr.h
+++ b/TD4_Game/GameSoundMgr.h
@@ -7,15 +7,15 @@ class GameSoundMgr
 {
 private:
 	//各音データ
-	SoundData titleBgm;
-	SoundData gameBgm;
-	SoundData resultBgm;
+	SoundData titleBgm = {};
+	SoundData gameBgm = {};
+	SoundData resultBgm = {};
 
-	std::array<SoundData,3> slapSe;
-	std::array<SoundData,2> cutSe;
-	SoundData pullSe;
-	SoundData buttonSe;
-	SoundData cancelSe;
+	std::array<SoundData, 3> slapSe = {};
+	std::array<SoundData, 2> cutSe = {};
+	SoundData pullSe = {};
+	SoundData buttonSe = {};
+	SoundData cancelSe = {};
 
 
 	GameSoundMgr() = default;

--- a/TD4_Game/Resources/Shaders/LIT_OBJPixelShader.hlsl
+++ b/TD4_Game/Resources/Shaders/LIT_OBJPixelShader.hlsl
@@ -21,11 +21,13 @@ float4 main(VSOutput input) : SV_TARGET
     //アルベド情報を取得
     float4 albedo = albedoTex.Sample(smp, input.uv);
     //法線情報取得
-    float3 normal = normalTex.Sample(smp, input.uv).xyz;
+    float3 normal = normalTex.Sample(smp, input.uv).rgb;
     //ワールド座標取得
     float3 worldPos = worldTex.Sample(smp, input.uv).xyz;
     //深度情報取得
     float4 depth = LdepthTex.Sample(smp, input.uv);
+    //スペキュラ強度取得
+    float specPower = normalTex.Sample(smp, input.uv).a;
     
     //法線情報を復元
     normal = (normal * 2.0f) - 1.0f;

--- a/TD4_Game/Resources/Shaders/OBJPixelShader.hlsl
+++ b/TD4_Game/Resources/Shaders/OBJPixelShader.hlsl
@@ -26,8 +26,8 @@ PixelOutput main(GSOutput input)
 	float4 texcolor = tex.Sample(smp, input.uv);
 	
     result.pixel_color = float4(texcolor.rgb, 1.0f );
-    result.normal.rgb = float3(input.normal.xyz / 2.0f) + 0.5f;
-    result.normal.a = 1.0f;
+    result.normal.xyz = float3(input.normal.xyz / 2.0f) + 0.5f;
+    result.normal.w = texcolor.a;
     result.worldPos = input.worldPos;
     
     //’ÊíƒJƒƒ‰‹óŠÔz’l

--- a/TD4_Game/Resources/mp3test.mp3
+++ b/TD4_Game/Resources/mp3test.mp3
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cc119680c3ecf4ea6621e1c08f81743c36041e9f8986c95d321b4188bce50394
+size 1477855

--- a/TD4_Game/Resources/mp3test.wav
+++ b/TD4_Game/Resources/mp3test.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a4832ba6625cc1d04e84697dab7e16bd9de998e09d13d105dff1639f8e59c9ea
+size 13045370

--- a/TD4_Game/imgui.ini
+++ b/TD4_Game/imgui.ini
@@ -9,8 +9,8 @@ Size=351,263
 Collapsed=0
 
 [Window][light ctrl]
-Pos=24,168
-Size=285,154
+Pos=211,24
+Size=285,266
 Collapsed=0
 
 [Window][Audio Control]


### PR DESCRIPTION
# engine更新

## wav読み込み修正

wavファイルが読み込めない場合がある問題を修正しました。

### 詳しい解説
WAVファイルのフォーマットについて
https://learn.microsoft.com/ja-jp/windows-hardware/drivers/audio/extensible-wave-format-descriptors

原因は、WAVEFORMATEX以外のフォーマットに対応していなかったためでした。