### PR TITLE
Engine

### DIFF
--- a/RakiEngine_Library/Audio.cpp
+++ b/RakiEngine_Library/Audio.cpp
@@ -133,7 +133,7 @@ SoundData Audio::LoadSound_wav(const char *filename)
     case FMT_BYTE_40:
         //WAVEFORMATEXに合わせる
         soundData->wfex = format.wften.Format;
-        soundData->wfex.wFormatTag = WORD(1);
+        soundData->wfex.wFormatTag = WORD(format.wften.SubFormat.Data1);
         //波形フォーマットをもとにソースの作成
         result = xAudio2->CreateSourceVoice(&soundData->source, &soundData->wfex);
         break;

--- a/TD4_Game/EngineDebugScene.cpp
+++ b/TD4_Game/EngineDebugScene.cpp
@@ -1,5 +1,7 @@
 #include "EngineDebugScene.h"
 
+#include "GameSoundMgr.h"
+
 #include <Raki_imguiMgr.h>
 #include <DirectionalLight.h>
 
@@ -124,6 +126,12 @@ void EngineDebugScene::Update()
 		pgstate.aliveTime = 60;
 		testp->Add(pgstate);
 	}
+
+
+
+	//‰¹ƒeƒXƒg
+	
+
 }
 
 void EngineDebugScene::Draw()
@@ -210,6 +218,36 @@ void EngineDebugScene::DrawImgui()
 	testFBX_YesBone->SetAffineParamRotate(RVector3(rotX, rotY, rotZ));
 	testobj->SetAffineParamRotate(RVector3(rotX, rotY, rotZ));
 	testobject->SetAffineParamRotate(RVector3(rotX, rotY, rotZ));
+
+
+	myImgui::StartDrawImGui("SOUND TEST", 100, 300);
+
+	if (ImGui::Button("PLAY TITLE BGM")) {
+		GameSoundMgr::get()->PlayTitleBGM();
+	}
+	if (ImGui::Button("PLAY GAME BGM")) {
+		GameSoundMgr::get()->PlayGameBGM();
+	}
+	if (ImGui::Button("PLAY RESULT BGM")) {
+		GameSoundMgr::get()->PlayResultBGM();
+	}
+	if (ImGui::Button("STOP TITLE BGM")) {
+		GameSoundMgr::get()->StopTitleBGM();
+	}
+	if (ImGui::Button("STOP GAME BGM")) {
+		GameSoundMgr::get()->StopGameBGM();
+	}
+	if (ImGui::Button("STOP RESULT BGM")) {
+		GameSoundMgr::get()->StopResultBGM();
+	}
+	if (ImGui::Button("CUT")) { GameSoundMgr::get()->PlayCutSE(); }
+	if (ImGui::Button("SLAP")) { GameSoundMgr::get()->PlaySlapSE(); }
+	if (ImGui::Button("BUTTON")) { GameSoundMgr::get()->PlayButtonSE(); }
+	if (ImGui::Button("CANCEL")) { GameSoundMgr::get()->PlayCancelSE(); }
+	if (ImGui::Button("PULL")) { GameSoundMgr::get()->PlayPullSE(); }
+
+
+	myImgui::EndDrawImGui();
 
 }
 

--- a/TD4_Game/EngineDebugScene.h
+++ b/TD4_Game/EngineDebugScene.h
@@ -51,6 +51,9 @@ public:
     //音
     SoundData testSE;
     SoundData testBGM;
+    //音テスト用
+
+
 
     Sprite testNum;
     int dval = 0;

--- a/TD4_Game/GameSoundMgr.cpp
+++ b/TD4_Game/GameSoundMgr.cpp
@@ -14,26 +14,26 @@ void GameSoundMgr::Init()
 
 
 	std::string ext = ".wav";
-	//for (int i = 0; i < 3; i++) {
-	//	std::string slapfilename = "slap";
-	//	std::string cutfilename = "cut";
-	//	std::string num = std::to_string(i + 1);
+	for (int i = 0; i < 3; i++) {
+		std::string slapfilename = "slap";
+		std::string cutfilename = "cut";
+		std::string num = std::to_string(i + 1);
 
-	//	std::string cutfilepass = pass + sefolder + cutfilename + num + ext;
-	//	std::string slapfilepass = pass + sefolder + cutfilename + num + ext;
+		std::string cutfilepass = pass + sefolder + cutfilename + num + ext;
+		std::string slapfilepass = pass + sefolder + slapfilename + num + ext;
 
-	//	if (i < 2) {
-	//		cutSe[i] = Audio::LoadSound_wav(cutfilepass.c_str());
-	//	}
-	//	slapSe[i] = Audio::LoadSound_wav(slapfilepass.c_str());
-	//}
-	//pullSe = Audio::LoadSound_wav("Resources/sounds/se/pull.wav");
-	//Audio::LoadSound_wav("Resources/sounds/se/ok.wav", &buttonSe);
-	//cancelSe = Audio::LoadSound_wav("Resources/sounds/se/cancel.wav");
+		if (i < 2) {
+			cutSe[i] = Audio::LoadSound_wav(cutfilepass.c_str());
+		}
+		slapSe[i] = Audio::LoadSound_wav(slapfilepass.c_str());
+	}
+	pullSe = Audio::LoadSound_wav("Resources/sounds/se/pull.wav");
+	buttonSe = Audio::LoadSound_wav("Resources/sounds/se/ok.wav");
+	cancelSe = Audio::LoadSound_wav("Resources/sounds/se/cancel.wav");
 
 	titleBgm = Audio::LoadSound_wav("Resources/sounds/bgm/titlebgm.wav");
 	gameBgm = Audio::LoadSound_wav("Resources/sounds/bgm/gamebgm.wav");
-	resultBgm = Audio::LoadSound_wav("Resources/sounds/bgm/gamebgm.wav");
+	resultBgm = Audio::LoadSound_wav("Resources/sounds/bgm/resultbgm.wav");
 
 	Audio::SetPlayRoopmode(titleBgm, 255);
 	Audio::SetPlayRoopmode(gameBgm, 255);

--- a/TD4_Game/GameSoundMgr.h
+++ b/TD4_Game/GameSoundMgr.h
@@ -7,9 +7,9 @@ class GameSoundMgr
 {
 private:
 	//各音データ
-	SoundData titleBgm = {};
-	SoundData gameBgm = {};
-	SoundData resultBgm = {};
+	SoundData titleBgm;
+	SoundData gameBgm;
+	SoundData resultBgm;
 
 	std::array<SoundData, 3> slapSe = {};
 	std::array<SoundData, 2> cutSe = {};
@@ -24,8 +24,8 @@ private:
 public:
 	static GameSoundMgr *get()
 	{
-		static GameSoundMgr* ins;
-		return ins;
+		static GameSoundMgr ins;
+		return &ins;
 	}
 
 	void Init();

--- a/TD4_Game/imgui.ini
+++ b/TD4_Game/imgui.ini
@@ -28,3 +28,8 @@ Pos=1024,113
 Size=318,655
 Collapsed=0
 
+[Window][SOUND TEST]
+Pos=569,26
+Size=280,430
+Collapsed=0
+

--- a/TD4_Game/main.cpp
+++ b/TD4_Game/main.cpp
@@ -55,7 +55,7 @@ int WINAPI WinMain(HINSTANCE, HINSTANCE, LPSTR, int)
 	std::unique_ptr<SceneManager> sceneMgr = std::make_unique<SceneManager>();
 
 
-	//GameSoundMgr::get()->Init();
+	GameSoundMgr::get()->Init();
 
 
 #pragma endregion GameValue


### PR DESCRIPTION
# engine app更新

## wavファイルのロード修正
wavファイルロードの修正で無理やり解決していた部分を修正

## ゲーム中に流れる音を管理するクラスを本実装、動作確認
GameSoundMgr classに音関係の処理を追加しています。
シングルトンなので好きなタイミングで関数を呼べば対応した音が再生されます。
